### PR TITLE
feat(node):  skip node chat server when scheduler_addr is not specified

### DIFF
--- a/src/parallax/launch.py
+++ b/src/parallax/launch.py
@@ -79,8 +79,6 @@ if __name__ == "__main__":
             if args.start_layer == 0:
                 http_server_process = launch_http_server(args)
             executor = Executor.create_from_args(args)
-            if not args.skip_node_chat_server:
-                node_chat_http_server_process = launch_node_chat_http_server(args)
             launch_p2p_server(
                 initial_peers=args.initial_peers,
                 scheduler_addr=args.scheduler_addr,
@@ -142,8 +140,7 @@ if __name__ == "__main__":
             if args.start_layer == 0:
                 http_server_process = launch_http_server(args)
             executor = Executor.create_from_args(args)
-            if not args.skip_node_chat_server:
-                node_chat_http_server_process = launch_node_chat_http_server(args)
+            node_chat_http_server_process = launch_node_chat_http_server(args)
 
         if gradient_server is not None:
             gradient_server.status = ServerState.READY

--- a/src/parallax/server/server_args.py
+++ b/src/parallax/server/server_args.py
@@ -150,10 +150,6 @@ def parse_args() -> argparse.Namespace:
         help="Choose the GPU moe kernels",
     )
 
-    parser.add_argument(
-        "--skip-node-chat-server", action="store_true", help="Skip node chat server"
-    )
-
     # Logging and debugging
     parser.add_argument(
         "--log-level",


### PR DESCRIPTION
## 📝 Change Type

Please select the type of change this PR introduces (choose one or more):

- [✅] **feat**: New feature.
- [ ] **fix**: Bug fix.
- [ ] **docs**: Documentation only changes.
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature.
- [ ] **perf**: Performance improvement.
- [ ] **test**: Adding missing tests or correcting existing tests.
- [ ] **chore**: Maintenance tasks (e.g., updating dependencies).

## 💡 Description

skip node chat server when scheduler_addr is not specified

### Key Changes
1. skip node chat server when scheduler_addr is not specified
2. fix a bug, which is a wrong key for find request in node http handler