### PR TITLE
add peak FP16 TFLOPS for M5 in AppleSiliconHardwareInfo

### DIFF
--- a/src/parallax/server/server_info.py
+++ b/src/parallax/server/server_info.py
@@ -74,6 +74,7 @@ class AppleSiliconHardwareInfo(HardwareInfo):
         "M4": 8.52,
         "M4 Pro": 17.04,
         "M4 Max": 34.08,
+        "M5": 10.27,
     }
 
     @classmethod


### PR DESCRIPTION
## 📝 Change Type

Please select the type of change this PR introduces (choose one or more):

- [x] **feat**: New feature.
- [ ] **fix**: Bug fix.
- [ ] **docs**: Documentation only changes.
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature.
- [ ] **perf**: Performance improvement.
- [ ] **test**: Adding missing tests or correcting existing tests.
- [ ] **chore**: Maintenance tasks (e.g., updating dependencies).

## 💡 Description

Adds hardware detection support for Apple's M5 chip by including its FP16 TFLOPS specifications in the hardware info dictionary. This enables the system to properly detect and report computational capabilities for M5-based Macs.

### Key Changes
1. Added "M5": 10.27 entry to `_APPLE_PEAK_FP16` dictionary in `AppleSiliconHardwareInfo` class
2. FP16 performance value (10.27 TFLOPS) calculated from CPU-Monkey benchmarks (FP32: 5.133 TFLOPS × 2)
3. Ensures M5 chips are recognized during hardware detection for scheduling decisions

## 🔗 Related Issues

List any issues this PR closes or relates to:

- N/A

## ✅ Checklist

Please ensure the following points are addressed before merging:

- [x] I have performed a self-review of my own code.
- [ ] I have added/updated tests that prove my fix or feature works (if applicable).
- [ ] I have updated the documentation (if necessary).
- [x] My code follows the project's style guidelines.