### PR TITLE
feat(python version): update python version to support 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "parallax"
 version = "0.1.2"
 description = "Decentralised pipeline-parallel LLM serving with Sglang + MLX-LM + Lattica"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.10,<3.14"
 packages = [
   { include = "parallax", from = "src" },
   { include = "scheduling", from = "src" },

--- a/src/parallax/cli.py
+++ b/src/parallax/cli.py
@@ -43,8 +43,8 @@ PUBLIC_RELAY_SERVERS = [
 
 
 def check_python_version():
-    """Check if Python version is 3.11 or higher."""
-    if sys.version_info < (3, 11) or sys.version_info >= (3, 14):
+    """Check if Python version is 3.10 or higher."""
+    if sys.version_info < (3, 10) or sys.version_info >= (3, 14):
         logger.info(
             f"Error: Python 3.11 or higher and less than 3.14 is required. Current version is {sys.version_info.major}.{sys.version_info.minor}."
         )


### PR DESCRIPTION
Update python version to support 3.10

Ubuntu 22.04 LTS default version is Python 3.10.12

Verified in my local setup.

## 📋 Update python version to support 3.10


The PR title should follow the format:

```
fix(scope): 
Ubuntu 22.04 LTS default version is Python 3.10.12
For most available cloud instances, the command `pip install -e '.[gpu]'` will fail.

However, the code actually support 3.10.12(Ubuntu 22.04 LTS default version)


```

Where:
- `type` is one of: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `chore`.
- `scope` is optional and describes the part of the codebase affected (e.g., `auth`, `ui`, `api`).
- `concise message` is a short description of the change (max 50 chars).

## 📝 Change Type

Please select the type of change this PR introduces (choose one or more):

- [ ] **feat**: New feature.
- [x] **fix**: Bug fix.
- [ ] **docs**: Documentation only changes.
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature.
- [ ] **perf**: Performance improvement.
- [ ] **test**: Adding missing tests or correcting existing tests.
- [ ] **chore**: Maintenance tasks (e.g., updating dependencies).

## 💡 Description

Briefly describe the change, its purpose, and the problem it solves.

### Key Changes
1. Support Ubuntu 22.04 LTS default version Python 3.10.12
2.
3.

## 🔗 Related Issues

List any issues this PR closes or relates to:

- Closes #IssueNumber (e.g., `Closes #123`)

## ✅ Checklist

Please ensure the following points are addressed before merging:

- [x] I have performed a self-review of my own code.
- [x] I have added/updated tests that prove my fix or feature works (if applicable).
- [] I have updated the documentation (if necessary).
- [x] My code follows the project's style guidelines.
