### PR TITLE
perf(scheduler): use deque for o(1) queue operations

### DIFF
--- a/src/parallax/server/scheduler.py
+++ b/src/parallax/server/scheduler.py
@@ -21,7 +21,7 @@ Our scheduler also handles tokenization and pre-processing for the First Peer's 
 
 import time
 from collections import OrderedDict, deque
-from typing import Deque, Dict, Optional
+from typing import Deque, Dict, List, Optional
 
 from parallax.server.kv_cache import KVCacheManager
 from parallax.server.request import InitialRequest, Request, RequestStatus


### PR DESCRIPTION

  Change Type

  - perf: Performance improvement.

  Description

  Replace list with collections.deque for the scheduler's wait queue. list.pop(0) is O(n) because it shifts all elements; deque.popleft() is O(1).

  Key Changes

  1. Changed _wait_queue type from List to Deque
  2. Changed .pop(0) to .popleft() in admit_requests()
  3. Updated imports accordingly

