### PR TITLE
fix(ui): correct grammar on setup screen

### DIFF
--- a/src/frontend/src/pages/setup.tsx
+++ b/src/frontend/src/pages/setup.tsx
@@ -100,7 +100,7 @@ export default function PageSetup() {
 
         <Stack direction='row' justifyContent='space-between' alignItems='center' gap={2}>
           <Typography color='text.secondary'>
-            Are you nodes within the same local network?
+            Are your nodes within the same local network?
           </Typography>
           <ToggleButtonGroup
             sx={{ width: '10rem', textTransform: 'none' }}


### PR DESCRIPTION
## 📝 Change Type

Please select the type of change this PR introduces (choose one or more):

- [ ] **feat**: New feature.
- [x] **fix**: Bug fix.
- [ ] **docs**: Documentation only changes.
- [ ] **refactor**: A code change that neither fixes a bug nor adds a feature.
- [ ] **perf**: Performance improvement.
- [ ] **test**: Adding missing tests or correcting existing tests.
- [ ] **chore**: Maintenance tasks (e.g., updating dependencies).

## 💡 Description

Fixes a small grammar typo on the initial setup screen shown after first running Parallax.

The text currently reads:
"Are you nodes within the same local network?"

It now correctly reads:
"Are your nodes within the same local network?"

### Key Changes
1. Corrected a grammatical error in the setup screen UI text.


## ✅ Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have added/updated tests that prove my fix or feature works (if applicable).
- [ ] I have updated the documentation (if necessary).
- [x] My code follows the project's style guidelines.
