### PR TITLE
fix(paged-attention): correct sliding window attention detection logic in mlx_executor

### DIFF
--- a/src/parallax/models/qwen2.py
+++ b/src/parallax/models/qwen2.py
@@ -10,8 +10,8 @@ from mlx_lm.models.qwen2 import Attention as MLXQwen2Attention
 from mlx_lm.models.qwen2 import ModelArgs
 from mlx_lm.models.qwen2 import TransformerBlock as MLXQwen2Block
 
-from parallax.metal.paged_attention.kernel import paged_attention, reshape_and_cache
 from parallax.server.cache.base import BaseCache
+from parallax_extensions.ops import paged_attention_v1, reshape_and_cache
 
 
 class ParallaxQwen2Attention(MLXQwen2Attention):
@@ -87,7 +87,7 @@ class ParallaxQwen2Attention(MLXQwen2Attention):
         # 3. Compute Attention
         if target_len == 1:
             # Decode Phase: Use Paged Attention Kernel
-            output = paged_attention(
+            output = paged_attention_v1(
                 queries_rotated,
                 key_cache_global,
                 value_cache_global,

--- a/src/parallax/server/executor/mlx_executor.py
+++ b/src/parallax/server/executor/mlx_executor.py
@@ -151,6 +151,9 @@ class MLXExecutor(BaseExecutor):
         time.sleep(5)
 
         sliding_window = self.config.get("sliding_window", None)
+        use_sliding_window = self.config.get("use_sliding_window", None)
+        if use_sliding_window is False:
+            sliding_window = None
 
         # Validate and adjust block size for Metal backend
         supported_block_sizes = [8, 16, 32, 64]


### PR DESCRIPTION
## 📝 Change Type

Please select the type of change this PR introduces (choose one or more):

- [x] **fix**: Bug fix.

## 💡 Description

This PR fixes a bug in the SWA detection logic that caused some models (like Qwen2) to be incorrectly identified as using Sliding Window Attention. 
In some model configurations (e.g., Qwen2), sliding_window may be defined while use_sliding_window is explicitly set to False.

### Key Changes
1. Updated MLXExecutor to honor the use_sliding_window flag.

## ✅ Checklist

Please ensure the following points are addressed before merging:

- [x] I have performed a self-review of my own code.
- [x] I have added/updated tests that prove my fix or feature works (if applicable).
- [x] I have updated the documentation (if necessary).
- [x] My code follows the project's style guidelines.
