### PR TITLE
fix(sglang): preserve tie_word_embeddings for single-node runs

### DIFF
--- a/src/parallax/sglang/model_runner.py
+++ b/src/parallax/sglang/model_runner.py
@@ -349,8 +349,13 @@ def initialize_sgl_model_runner(
         dtype=dtype,
         quantization=quant_method,
     )
-    # TODO: Fix me
-    model_config.hf_config.tie_word_embeddings = False
+    # Only disable tie_word_embeddings when running a partial layer range
+    # (multi-node PP where this node doesn't have both embed_tokens and lm_head).
+    # For single-node or full-range runs, keep the original setting so that
+    # lm_head correctly shares weights with embed_tokens.
+    num_hidden_layers = model_config.hf_config.num_hidden_layers
+    if start_layer > 0 or end_layer < num_hidden_layers:
+        model_config.hf_config.tie_word_embeddings = False
     model_config.hf_config.start_layer = start_layer
     model_config.hf_config.end_layer = end_layer
 


### PR DESCRIPTION
## Summary

- Fixes garbage/random output for all models with `tie_word_embeddings=True` (e.g., Qwen3-4B, Qwen3-8B-Instruct) when running on single-node or full-layer-range configurations
- Root cause: `model_runner.py` unconditionally set `model_config.hf_config.tie_word_embeddings = False` (line 352, marked `# TODO: Fix me`), causing `lm_head` to be created as a separate `ParallelLMHead` with zero-initialized weights instead of being tied to `embed_tokens`
- Fix: only disable `tie_word_embeddings` when the node runs a partial layer range (multi-node PP)

## Root Cause Analysis

For models with `tie_word_embeddings=True`, there is no separate `lm_head.weight` tensor in the safetensors files — the weight is shared with `embed_tokens.weight`. SGLang's `Qwen2ForCausalLM.__init__` handles this correctly when `pp_group.world_size == 1` by setting `self.lm_head = self.model.embed_tokens`.

However, Parallax unconditionally forced `tie_word_embeddings = False`, which caused:
1. `lm_head` created as a fresh `ParallelLMHead` (not tied to embed_tokens)
2. No `lm_head.weight` found in safetensors → weights stay zero-initialized
3. Forward pass computes logits from a zeroed lm_head → garbage tokens

## Test plan

- [x] Verified `lm_head.weight` is all zeros before fix (mean=0.000000, std=0.000000)
- [x] Verified `lm_head` correctly tied to `embed_tokens` after fix (same data pointer)
- [x] Tested Qwen3-4B (tie_word_embeddings=True): coherent output ("What is 2+2?" → correct reasoning)
- [x] Tested via Parallax `launch.py` with `--gpu-backend sglang --attention-backend torch_native`
- [x] Confirmed vLLM backend still works (unaffected by this change)
- [ ] Needs testing with actual multi-node PP to verify partial-range models still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)