### PR TITLE
fix(server_info): add m5 series apple silicon chips to _apple_peak_fp16

### DIFF
--- a/src/parallax/server/server_info.py
+++ b/src/parallax/server/server_info.py
@@ -75,6 +75,10 @@ class AppleSiliconHardwareInfo(HardwareInfo):
         "M4": 8.52,
         "M4 Pro": 17.04,
         "M4 Max": 34.08,
+        "M5": 9.37,
+        "M5 Pro": 18.74,
+        "M5 Max": 37.49,
+        "M5 Ultra": 74.98,
     }
 
     @classmethod


### PR DESCRIPTION
Running `parallax join` on M5 Max hardware crashes with:

```
RuntimeError: Unknown Apple silicon chip 'M5 Max' detected.
Please add it to the _APPLE_PEAK_FP16 dictionary.
```

Add M5, M5 Pro, M5 Max, and M5 Ultra entries to the `_APPLE_PEAK_FP16`
dictionary so that Apple M5 hardware is recognized correctly.

Fixes #439