### PR TITLE
fix: correct Discord invite link in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Welcome to **Parallax**, we're glad you're interested in contributing! We welcom
 
 We encourage everyone—first-time contributors and experienced developers alike—to follow these best practices for a smooth collaboration process.
 
-If you have any questions, feel free to ask in our [Discord channel](https://discord.gg/parallax).
+If you have any questions, feel free to ask in our [Discord channel](https://discord.gg/parallaxai).
 
 ## How Can I Contribute?
 


### PR DESCRIPTION
## 📋 PR Title Format

fix: correct Discord invite link in CONTRIBUTING.md

## 📝 Change Type

- [x] fix: Bug fix.

## 💡 Description

The CONTRIBUTING.md currently contains an incorrect Discord invite link `https://discord.gg/parallax` which leads to a different, potentially unsafe Discord server. The correct link is `https://discord.gg/parallaxai` as used in README.md. This PR replaces the incorrect link with the correct one.

### Key Changes
1. Updated Discord invite link in `docs/CONTRIBUTING.md` from `discord.gg/parallax` to `discord.gg/parallaxai`.

## 🔗 Related Issues

None (documentation fix).

## ✅ Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have added/updated tests that prove my fix or feature works (not applicable).
- [x] I have updated the documentation (if necessary).
- [x] My code follows the project's style guidelines.