### PR TITLE
docs: fix typo "architechture" in installation guide

### DIFF
--- a/docs/user_guide/install.md
+++ b/docs/user_guide/install.md
@@ -73,7 +73,7 @@ parallax --help
 ```
 
 ### Docker
-For Linux+GPU devices, Parallax provides a docker environment for quick setup. Choose the docker image according to the device's GPU architechture.
+For Linux+GPU devices, Parallax provides a docker environment for quick setup. Choose the docker image according to the device's GPU architecture.
 
 |  GPU Architecture  |  GPU Series  | Image Pull Command |
 |:-------------|:----------------------------|:----------------------------|


### PR DESCRIPTION
## 📝 Change Type
- [x] **docs**: Documentation only changes.

## 💡 Description
Fixed a typo in the Docker installation section of the user guide.

### Key Changes
1. `"architechture"` → `"architecture"` in the Docker GPU architecture table

## 🔗 Related Issues
None

## ✅ Checklist
- [x] I have performed a self-review of my own code.
- [ ] I have added/updated tests that prove my fix or feature works (if applicable).
- [x] I have updated the documentation (if necessary).
- [x] My code follows the project's style guidelines.