### PR TITLE
fix: allow uv prerelease installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,7 @@ install_parallax_python() {
     fi
 
     echo "Installing Parallax Python package: $package_spec"
-    uv pip install --python "$venv_python" -e "$package_spec"
+    UV_PRERELEASE=allow uv pip install --python "$venv_python" -e "$package_spec"
 }
 
 resolve_venv_bin_dir() {


### PR DESCRIPTION
## Summary

- Set `UV_PRERELEASE=allow` on the `uv pip install` command in `install.sh`.
- Keeps the prerelease opt-in scoped to the package installation step only.

## Validation

- `bash -n install.sh`
- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/pytest`