### PR TITLE
docs: overhaul README — multi-device positioning, device-selection quickstart, runtime stack table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,95 @@
 <div align="center">
-  <p align="center">
-    <img src="docs/images/parallax.png" width="720">
-    <div align="center">
-      <p style="font-size: 1.3em; font-weight: 600; margin-bottom: 10px;">Trusted by Partners</p>
-      <img src="docs/images/sglang.png" alt="SGLang" height="28" style="margin: 0 20px;">
-      <img src="docs/images/vllm.png" alt="vLLM" height="30" style="margin: 0 20px;">
-      <img src="docs/images/qwen.avif" alt="Qwen" height="30" style="margin: 0 20px;">
-      <img src="docs/images/deepseek.png" alt="DeepSeek" height="30" style="margin: 0 20px;">
-      <img src="docs/images/kimi.png" alt="Kimi" height="30" style="margin: 0 20px;">
-      <img src="docs/images/minimax.png" alt="Minimax" height="30" style="margin: 0 10px;">
-      <img src="docs/images/zai.svg" alt="ZAI" height="30" style="margin: 0 10px;"/>
-    </div>
+  <img src="docs/images/parallax.png" width="720" alt="Parallax">
+
+  <h1>Parallax</h1>
+
+  <p><strong>Distributed LLM serving across Macs, Windows PCs, and GPU machines.</strong></p>
+  <p>
+    Build an OpenAI-compatible inference cluster with mixed-device setup,
+    automatic node discovery, pipeline-parallel sharding, and a browser setup flow.
   </p>
 
-[![license](https://img.shields.io/github/license/GradientHQ/parallax.svg)](https://github.com/GradientHQ/parallax/tree/main/LICENSE)
-[![issue resolution](https://img.shields.io/github/issues-closed-raw/GradientHQ/parallax)](https://github.com/GradientHQ/parallax/issues)
-[![open issues](https://img.shields.io/github/issues-raw/GradientHQ/parallax)](https://github.com/GradientHQ/parallax/issues)
+  [![Latest release](https://img.shields.io/github/v/release/GradientHQ/parallax?label=release)](https://github.com/GradientHQ/parallax/releases)
+  [![License](https://img.shields.io/github/license/GradientHQ/parallax.svg)](./LICENSE)
+  [![Python](https://img.shields.io/badge/python-3.11--3.13-blue)](./pyproject.toml)
+  [![Issues](https://img.shields.io/github/issues-raw/GradientHQ/parallax)](https://github.com/GradientHQ/parallax/issues)
 
-<a href="https://www.producthunt.com/products/parallax-by-gradient?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_source=badge-parallax&#0045;by&#0045;gradient" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1030922&theme=light&period=daily&t=1761986433128" alt="Parallax&#0032;by&#0032;Gradient - Host&#0032;LLMs&#0032;across&#0032;devices&#0032;sharing&#0032;GPU&#0032;to&#0032;make&#0032;your&#0032;AI&#0032;go&#0032;brrr | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
+  <p>
+    <a href="#quickstart">Quickstart</a> ·
+    <a href="#supported-models">Models</a> ·
+    <a href="#dashboard">Dashboard</a> ·
+    <a href="#runtime-stack">Runtime</a> ·
+    <a href="#features">Features</a> ·
+    <a href="#architecture">Architecture</a> ·
+    <a href="#news">News</a> ·
+    <a href="#docs">Docs</a>
+  </p>
 
+  <p>
+    <a href="https://gradient.network">Gradient</a> ·
+    <a href="https://gradient.network/blog/parallax-the-sovereign-ai-os">Blog</a> ·
+    <a href="https://discord.gg/parallaxai">Discord</a> ·
+    <a href="https://x.com/tryParallax">X</a> ·
+    <a href="https://arxiv.org/pdf/2509.26182v1">Paper</a>
+  </p>
+
+  <a href="https://www.producthunt.com/products/parallax-by-gradient?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_source=badge-parallax&#0045;by&#0045;gradient" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1030922&theme=light&period=daily&t=1761986433128" alt="Parallax by Gradient - Product Hunt Top Post" width="250" height="54" /></a>
+
+  <p><strong>Works with</strong></p>
+  <p>
+    <img src="docs/images/sglang.png" alt="SGLang" height="28">
+    &nbsp;&nbsp;&nbsp;
+    <img src="docs/images/vllm.png" alt="vLLM" height="30">
+    &nbsp;&nbsp;&nbsp;
+    <img src="docs/images/qwen.avif" alt="Qwen" height="30">
+    &nbsp;&nbsp;&nbsp;
+    <img src="docs/images/deepseek.png" alt="DeepSeek" height="30">
+    &nbsp;&nbsp;&nbsp;
+    <img src="docs/images/kimi.png" alt="Kimi" height="30">
+    &nbsp;&nbsp;&nbsp;
+    <img src="docs/images/minimax.png" alt="MiniMax" height="30">
+    &nbsp;&nbsp;&nbsp;
+    <img src="docs/images/zai.svg" alt="ZAI" height="30">
+  </p>
 </div>
 
-| [**Gradient**](https://gradient.network)
-| [**Blog**](https://gradient.network/blog/parallax-the-sovereign-ai-os)
-| [**X(Twitter)(Gradient)**](https://x.com/Gradient_HQ)
-| [**X(Twitter)(Parallax)**](https://x.com/tryParallax)
-| [**Discord**](https://discord.gg/parallaxai)
-| [**Arxiv**](https://arxiv.org/pdf/2509.26182v1)
-
 ## News
+
+- [2026/6] 🚀 Parallax now supports ModelScope downloads! Prefix any command with `USE_MODELSCOPE=1`.
+- [2026/5] 🍎 Added Apple M5 series chip support for Mac workers.
 - [2026/2] 🦞 Parallax now supports OpenClaw integration! See [Docs](./docs/user_guide/work_with_openclaw.md)
 - [2025/10] 🔥 Parallax won #1 Product of The Day on Product Hunt!
 - [2025/10] 🔥 Parallax version 0.0.1 has been released!
 
-## About
-A fully decentralized inference engine developed by [Gradient](https://gradient.network). Parallax lets you build your own AI cluster for model inference onto a set of distributed nodes despite their varying configuration and physical location. Its core features include:
+## Why Parallax
 
-- **Host local LLM on personal devices**
-- **Cross-platform support**
-- **Pipeline parallel model sharding**
-- **Paged KV cache management & continuous batching for Mac**
-- **Dynamic request scheduling and routing for high performance**
+Parallax is a decentralized inference engine from [Gradient](https://gradient.network). It turns multiple local or remote machines into one serving cluster, so you can host larger open models and route requests across heterogeneous hardware without putting every weight on a single box.
 
-The backend architecture:
+Use Parallax when you want to:
 
-* P2P communication powered by [Lattica](https://github.com/GradientHQ/lattica)
-* GPU backend powered by [SGLang](https://github.com/sgl-project/sglang) and [vLLM](https://github.com/vllm-project/vllm)
-* MAC backend powered by [MLX LM](https://github.com/ml-explore/mlx-lm)
+- Run one model across multiple worker nodes with pipeline-parallel layer sharding.
+- Serve an OpenAI-compatible API (`/v1/models`, `/v1/chat/completions`) from your own machines. Other OpenAI endpoints may not be available.
+- Mix Apple Silicon Macs, Windows PCs, and Linux GPU hosts in the same cluster.
+- Use GPU backends (SGLang, vLLM) and the Mac MLX backend behind one API.
+- Bring nodes together on a LAN or through Lattica relay servers for remote clusters.
+- Manage setup, model selection, node joining, and chat from a browser UI.
 
-## User Guide
+## Quickstart
 
-- [Installation](./docs/user_guide/install.md)
-- [Getting Started](./docs/user_guide/quick_start.md)
-- [Working with OpenClaw 🦞](./docs/user_guide/work_with_openclaw.md)
+This path starts a scheduler with the web UI, joins worker nodes, and sends a request through the OpenAI-compatible API.
 
-## Quick Install
+### 1. Choose an install path
+
+Different devices use different install paths. After installation, the cluster workflow is the same: start a scheduler, join workers, then call the OpenAI-compatible API.
+
+| Device | Recommended path | Commands |
+|:--|:--|:--|
+| Apple Silicon macOS | Source install with Mac extras | `git clone https://github.com/GradientHQ/parallax.git`<br>`cd parallax`<br>`./install.sh --extras mac`<br>`source .venv/bin/activate` |
+| Linux / WSL GPU host | Source install with GPU extras | `git clone https://github.com/GradientHQ/parallax.git`<br>`cd parallax`<br>`./install.sh --extras gpu`<br>`source .venv/bin/activate` |
+| Windows PC | Windows app | Download [Parallax_Win_Setup.exe](https://github.com/GradientHQ/parallax_win_cli/releases/latest/download/Parallax_Win_Setup.exe), open Windows Terminal as administrator, then run `parallax install`. |
+| Linux GPU container | Docker | `docker run -it --gpus all --network host gradientservice/parallax:latest bash` (use `:latest-spark` for DGX Spark / GB10). |
+
+For macOS and Linux, the default source install also auto-selects the right extras:
 
 ```sh
 git clone https://github.com/GradientHQ/parallax.git
@@ -63,24 +98,193 @@ cd parallax
 source .venv/bin/activate
 ```
 
-The install script installs `uv` if needed, creates `.venv`, installs Parallax,
-and builds the `vllm-rs` frontend binary into `.venv/bin`. Use
-`./install.sh --extras gpu` on Linux/WSL GPU hosts or `./install.sh --extras mac`
-on Apple silicon macOS. For development dependencies, use `--extras gpu,dev` or
-`--extras mac,dev`.
+The installer creates `.venv`, installs Parallax, selects the default extras for your platform, and builds the `vllm-rs` frontend binary into `.venv/bin`.
 
-## Contributing
+### 2. Start the scheduler
 
-We warmly welcome contributions of all kinds! For guidelines on how to get involved, please refer to our [Contributing Guide](./docs/CONTRIBUTING.md).
+Run this on the machine that should host the setup UI and API:
+
+```sh
+parallax run
+```
+
+Open [http://localhost:3001](http://localhost:3001), choose a model and node count, then continue to the join screen.
+
+To expose the scheduler to other machines on your network:
+
+```sh
+parallax run --host 0.0.0.0
+```
+
+For nodes outside the same LAN, enable relay mode:
+
+```sh
+parallax run -r
+```
+
+### 3. Join workers
+
+Run the generated join command on each worker node. For a local network cluster, the command is usually:
+
+```sh
+parallax join
+```
+
+For remote or public-network nodes, use the scheduler address shown in the UI or logs:
+
+```sh
+parallax join -s <scheduler-address>
+```
+
+When all nodes are connected, Parallax routes you to the chat interface.
+
+### 4. Call the API
+
+```sh
+curl http://localhost:3001/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "<model>",
+    "messages": [{"role": "user", "content": "hello"}],
+    "max_tokens": 256,
+    "stream": true
+  }'
+```
+
+Use the model ID you chose in the setup UI, or fetch the active model from `GET /v1/models`.
+
+### Headless quickstart
+
+If you do not need the setup UI, start the scheduler with a model and expected worker count:
+
+```sh
+# terminal 1
+parallax run -m Qwen/Qwen3-0.6B -n 2
+
+# terminal 2 and each worker node
+parallax join
+```
+
+To run a single standalone server without the dashboard or scheduler:
+
+```sh
+parallax serve --model-path Qwen/Qwen3-0.6B
+```
+
+### Downloading from ModelScope
+
+Parallax downloads model weights from Hugging Face by default. To pull from ModelScope instead, set `USE_MODELSCOPE=1` on any Parallax process that resolves or loads the model. Use a model ID that exists on ModelScope.
+
+```sh
+USE_MODELSCOPE=1 parallax run -m Qwen/Qwen3-0.6B -n 2
+USE_MODELSCOPE=1 parallax join -s <scheduler-address>
+USE_MODELSCOPE=1 parallax serve --model-path Qwen/Qwen3-0.6B
+```
 
 ## Supported Models
 
-|              | Provider     | HuggingFace Collection  |  Blog  | Description |
-|:-------------|:-------------|:----------------------------:|:----------------------------:|:----------------------------|
-|DeepSeek      | Deepseek     | [DeepSeek-V3.2](https://huggingface.co/deepseek-ai/DeepSeek-V3.2)<br>[DeepSeek-R1](https://huggingface.co/collections/deepseek-ai/deepseek-r1) <br>| [Deep Seek AI Launches Revolutionary Language Model](https://deepseek.ai/blog/deepseek-v32) | Deep Seek AI is proud to announce the launch of our latest language model, setting new standards in natural language processing and understanding. This breakthrough represents a significant step forward in AI technology, offering unprecedented capabilities in text generation, comprehension, and analysis. |
-|MiniMax-M2    | MiniMax AI  | [MiniMax-M2](https://huggingface.co/MiniMaxAI/MiniMax-M2)<br>[MiniMax-M2.1](https://huggingface.co/MiniMaxAI/MiniMax-M2.1)<br>[MiniMax-M2.7](https://huggingface.co/MiniMaxAI/MiniMax-M2.7) | [MiniMax M2.1: Significantly Enhanced Multi-Language Programming](https://www.minimax.io/news/minimax-m21) | MiniMax-M2.7 and MiniMax-M2.1 are enhanced sparse MoE models (about 230B parameters, 10B active) built for advanced coding and agentic workflows. They offer state-of-the-art intelligence, delivering efficient, reliable tool use and strong multi-step reasoning. |
-|GLM           | Z AI | [GLM-5](https://huggingface.co/zai-org/GLM-5) <br>[GLM-5.1](https://huggingface.co/zai-org/GLM-5.1) | [GLM-5.1 Overview](https://docs.z.ai/guides/llm/glm-5.1) | "GLM" is an advanced large language model series from Z AI, including GLM-5 and GLM-5.1. These models feature long-context support, strong coding and reasoning performance, enhanced tool-use and agent integration, and competitive results across leading open-source benchmarks. |
-|Kimi-K2       | Moonshot AI  | [Kimi-K2](https://huggingface.co/collections/moonshotai/kimi-k2-6871243b990f2af5ba60617d) | [Kimi K2: Open Agentic Intelligence](https://moonshotai.github.io/Kimi-K2/) | "Kimi-K2" is Moonshot AI's Kimi-K2 model family, including Kimi-K2-Base, Kimi-K2-Instruct and Kimi-K2-Thinking. Kimi K2 Thinking is a state-of-the-art open-source agentic model designed for deep, step-by-step reasoning and dynamic tool use. It features native INT4 quantization and a 256k context window for fast, memory-efficient inference. Uniquely stable in long-horizon tasks, Kimi K2 enables reliable autonomous workflows with consistent performance across hundreds of tool calls.
-|Qwen          | Qwen         | [Qwen3-Next](https://huggingface.co/collections/Qwen/qwen3-next-68c25fd6838e585db8eeea9d) <br>[Qwen3](https://huggingface.co/collections/Qwen/qwen3-67dd247413f0e2e4f653967f) <br>[Qwen2.5](https://huggingface.co/collections/Qwen/qwen25-66e81a666513e518adb90d9e)| [Qwen3-Next: Towards Ultimate Training & Inference Efficiency](https://qwen.ai/blog?id=4074cca80393150c248e508aa62983f9cb7d27cd&from=research.latest-advancements-list) | The Qwen series is a family of large language models developed by Alibaba's Qwen team. It includes multiple generations such as Qwen2.5, Qwen3, and Qwen3-Next, which improve upon model architecture, efficiency, and capabilities. The models are available in various sizes and instruction-tuned versions, with support for cutting-edge features like long context and quantization. Suitable for a wide range of language tasks and open-source use cases. |
-|gpt-oss       | OpenAI       | [gpt-oss](https://huggingface.co/collections/openai/gpt-oss-68911959590a1634ba11c7a4) <br>[gpt-oss-safeguard](https://huggingface.co/collections/openai/gpt-oss-safeguard) | [Introducing gpt-oss-safeguard](https://openai.com/index/introducing-gpt-oss-safeguard/) | gpt-oss are OpenAI’s open-weight GPT models (20B & 120B). The gpt-oss-safeguard variants are reasoning-based safety classification models: developers provide their own policy at inference, and the model uses chain-of-thought to classify content and explain its reasoning. This allows flexible, policy-driven moderation in complex or evolving domains, with open weights under Apache 2.0. |
-|Meta Llama 3  | Meta         | [Meta Llama 3](https://huggingface.co/collections/meta-llama/meta-llama-3-66214712577ca38149ebb2b6) <br>[Llama 3.1](https://huggingface.co/collections/meta-llama/llama-31-669fc079a0c406a149a5738f) <br>[Llama 3.2](https://huggingface.co/collections/meta-llama/llama-32-66f448ffc8c32f949b04c8cf) <br>[Llama 3.3](https://huggingface.co/collections/meta-llama/llama-33-67531d5c405ec5d08a852000) | [Introducing Meta Llama 3: The most capable openly available LLM to date](https://ai.meta.com/blog/meta-llama-3/) | "Meta Llama 3" is Meta's third-generation Llama model, available in sizes such as 8B and 70B parameters. Includes instruction-tuned and quantized (e.g., FP8) variants. |
+Parallax supports a growing set of open model families. On Apple Silicon, many public Hugging Face IDs are mapped to MLX-optimized variants automatically. Recent model work expanded Qwen3.6/Qwen3.5 architecture support, GLM-5.1, MiniMax-M2.7, Step-3.5-Flash, DeepSeek-V3.2, Kimi-K2 Thinking, and gpt-oss safeguard coverage.
+
+| Family | Example model IDs | Notes |
+|:--|:--|:--|
+| Qwen | `Qwen/Qwen3-0.6B`, `Qwen/Qwen3-32B`, `Qwen/Qwen3-Next-80B-A3B-Instruct`, `Qwen/Qwen3.6-27B`, `Qwen/Qwen3-235B-A22B-GPTQ-Int4` | Dense, MoE, Next, Qwen3.6/Qwen3.5 architecture, thinking, FP8, GPTQ, and MLX variants. |
+| DeepSeek | `deepseek-ai/DeepSeek-V3.2`, `deepseek-ai/DeepSeek-R1`, `deepseek-ai/DeepSeek-V3.1` | V3.2, R1, and earlier large reasoning/MoE families. |
+| Kimi-K2 | `moonshotai/Kimi-K2-Instruct`, `moonshotai/Kimi-K2-Instruct-0905`, `moonshotai/Kimi-K2-Thinking` | Instruct and thinking model variants with MLX mappings. |
+| MiniMax | `MiniMaxAI/MiniMax-M2`, `MiniMaxAI/MiniMax-M2.1`, `MiniMaxAI/MiniMax-M2.7` | Sparse MoE coding and agent models, including M2.7. |
+| GLM / Z.ai | `zai-org/GLM-4.7`, `zai-org/GLM-4.7-Flash`, `zai-org/GLM-5.1` | GLM 4.x, Flash, FP8, and 5.1 families with MLX mappings. |
+| gpt-oss | `openai/gpt-oss-20b`, `openai/gpt-oss-120b`, `openai/gpt-oss-safeguard-20b`, `openai/gpt-oss-safeguard-120b` | Open-weight GPT and safeguard models. |
+| Llama | `nvidia/Llama-3.1-8B-Instruct-FP8`, `nvidia/Llama-3.3-70B-Instruct-FP8` | FP8 Llama serving paths. |
+| StepFun | `stepfun-ai/Step-3.5-Flash` | Additional large-model serving target. |
+
+See [`src/backend/server/static_config.py`](./src/backend/server/static_config.py) for the current model map.
+
+## Dashboard
+
+Parallax ships with a browser setup and chat flow at `http://localhost:3001`, so the first cluster can be launched without hand-writing node configuration.
+
+| Setup | Join workers | Chat |
+|:--:|:--:|:--:|
+| ![Model and node setup](./docs/images/node_config.png) | ![Node join command](./docs/images/node_join.png) | ![Chat interface](./docs/images/chat_interface.png) |
+
+## Runtime Stack
+
+Current pins from `pyproject.toml` and the latest GitHub `main` install script:
+
+| Component | Version | Used for |
+|:--|:--|:--|
+| SGLang | `sglang[all]==0.5.12` | Linux/WSL GPU backend. |
+| vLLM | `vllm==0.14.0` | Optional GPU backend and vLLM compatibility path. |
+| vLLM Rust frontend | `v0.22.0` on current GitHub `main` | Rust frontend binary built by `./install.sh`. |
+| MLX-LM | `mlx-lm==0.31.3` | Apple Silicon model execution and model utilities. |
+| MLX | `mlx==0.31.2` / `mlx[cpu]==0.31.2` | Mac backend and CPU-side MLX compatibility. |
+| Lattica | `lattica==1.0.21` | P2P discovery, messaging, and relay-assisted remote clusters. |
+| Transformers | `>=4.57.1` | Tokenizer/model config compatibility. |
+
+## Features
+
+- **Automatic cluster setup**: launch a scheduler, copy the join command, and let nodes discover the cluster through Lattica.
+- **Pipeline-parallel model sharding**: split model layers across workers so one deployment can use memory and compute from multiple devices.
+- **Dynamic scheduling and routing**: route requests through available pipelines based on live node state.
+- **Multiple execution backends**: SGLang and vLLM for GPU hosts, MLX-LM for Apple Silicon Macs.
+- **Paged KV cache and continuous batching on Mac**: improve local serving throughput and memory behavior for supported MLX paths. Recent main also adds chunked prefill (MLX and SGLang), linear prefix cache, and paged attention v2 for long context.
+- **Browser UI**: configure the model, watch nodes join, inspect cluster status, and chat from the built-in frontend.
+- **OpenAI-compatible API**: point existing clients at `http://localhost:3001/v1`. Current compatibility focuses on `/v1/models` and `/v1/chat/completions`; other OpenAI endpoints may not be available.
+- **Standalone server**: run a single-host setup with `parallax serve --model-path <model>` when you do not need the scheduler/dashboard.
+- **ModelScope downloads**: prefix any Parallax command with `USE_MODELSCOPE=1` to pull weights from ModelScope instead of Hugging Face.
+- **Remote cluster support**: use public relay servers when nodes are not on the same LAN.
+- **OpenClaw integration**: connect Parallax as a local model provider for OpenClaw.
+
+## Architecture
+
+Parallax is split into a scheduler/API process and worker node processes:
+
+- The scheduler runs the setup UI and OpenAI-compatible API on port `3001`.
+- Workers run model shards and local HTTP servers on port `3000`.
+- Optional chat clients can run with `parallax chat` and serve a chat UI on port `3002`.
+- Lattica handles P2P communication, discovery, and relay-assisted remote connections.
+- The scheduler computes layer allocation, tracks node state, and forwards requests through the selected pipeline.
+
+Backend stack:
+
+- [Lattica](https://github.com/GradientHQ/lattica) for P2P networking.
+- [SGLang](https://github.com/sgl-project/sglang) and [vLLM](https://github.com/vllm-project/vllm) for GPU execution.
+- [MLX-LM](https://github.com/ml-explore/mlx-lm) for Apple Silicon execution.
+
+## Docs
+
+- [Installation Guide](./docs/user_guide/install.md)
+- [Getting Started](./docs/user_guide/quick_start.md)
+- [Working with OpenClaw](./docs/user_guide/work_with_openclaw.md)
+- [Contributing Guide](./docs/CONTRIBUTING.md)
+
+## Development
+
+```sh
+./install.sh --extras mac,dev
+# or
+./install.sh --extras gpu,dev
+
+pre-commit run --all-files
+pytest
+```
+
+For low-level backend debugging, you can start a single node directly:
+
+```sh
+python src/parallax/launch.py --model-path Qwen/Qwen3-0.6B --log-level DEBUG
+```
+
+## Troubleshooting
+
+- If workers cannot see the scheduler on a LAN, start the scheduler with `--host 0.0.0.0` and confirm firewall rules allow scheduler port `3001`, worker port `3000`, and the selected TCP/UDP Lattica ports.
+- On macOS, allow Terminal, iTerm2, VS Code, Cursor, or your chosen shell app to access the Local Network in System Settings.
+- On WSL, use mirrored networking mode so other machines on the LAN can reach the scheduler.
+- For remote clusters, use the generated `parallax join -s <scheduler-address>` command and relay mode from the setup flow.
+
+## Contributing
+
+Contributions are welcome. Please read the [Contributing Guide](./docs/CONTRIBUTING.md), run the relevant tests, and open a pull request with a clear description of the change.
+
+## License
+
+Parallax is licensed under the [Apache 2.0 License](./LICENSE).


### PR DESCRIPTION
## What

A README overhaul that repositions Parallax around its full device story (Macs, Windows PCs, and GPU machines) and restructures the top of the doc for first-time users.

## Why

The previous README led with a source `git clone` and surfaced Windows support only deep inside the Install section. New users land without an obvious "which path do I take for my machine" answer, and the model list — the main reason people evaluate Parallax — sat far down the page.

## What's included

- **Repositioned tagline**: "Distributed LLM serving across Macs, Windows PCs, and GPU machines" — promotes Windows to a first-class device alongside Mac and GPU hosts.
- **Device-selection Quickstart**: step 1 is now a four-row table (Apple Silicon macOS / Linux GPU / Windows / Docker) mapping each device to its recommended install path, before falling back to the default source install.
- **Supported Models moved up** (right after Quickstart) and refreshed: Qwen3.6/Qwen3.5 architecture, GLM-5.1, MiniMax-M2.7, Step-3.5-Flash, DeepSeek-V3.2, Kimi-K2 Thinking, gpt-oss safeguard.
- **New Runtime Stack table**: pinned versions for SGLang, vLLM, vLLM Rust frontend, MLX-LM, MLX, Lattica, and Transformers, with what each is used for.
- **Expanded nav, Updates, and Requirements** to reflect the above (Windows app guidance, runtime refresh notes).

## Verification

All version numbers in the new Runtime Stack table and Recent Updates were checked against the current `main`:

- `sglang[all]==0.5.12`, `vllm==0.14.0`, `mlx-lm==0.31.3`, `mlx==0.31.2`, `lattica==1.0.21`, `transformers>=4.57.1`, `requires-python = ">=3.11,<3.14"` — all match `pyproject.toml`.
- vLLM Rust frontend `v0.22.0` — matches `VLLM_REF` default in `install.sh`.
- `kernels<0.15` (GPU extra) and `UV_PRERELEASE=allow` — both present in source.

This PR touches `README.md` only.
