### PR TITLE
feat: make scheduler openai agent compatible

### DIFF
--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
+from backend.server.openai_compat import openai_error_response, openai_models_payload
 from backend.server.request_handler import RequestHandler
 from backend.server.scheduler_manage import SchedulerManage
 from backend.server.server_args import parse_args
@@ -81,6 +82,18 @@ async def model_list():
         },
         status_code=200,
     )
+
+
+@app.get("/v1/models")
+async def openai_v1_models():
+    model_name = None
+    if scheduler_manage is not None:
+        try:
+            model_name = scheduler_manage.get_model_name()
+        except Exception as e:
+            logger.debug(f"Unable to get scheduler model name: {e}")
+
+    return JSONResponse(content=openai_models_payload(model_name), status_code=200)
 
 
 @app.post("/scheduler/init")
@@ -182,7 +195,23 @@ async def cluster_status_json() -> JSONResponse:
 
 @app.post("/v1/chat/completions")
 async def openai_v1_chat_completions(raw_request: Request):
-    request_data = await raw_request.json()
+    try:
+        request_data = await raw_request.json()
+    except Exception:
+        return openai_error_response(
+            "Invalid request body",
+            status_code=400,
+            err_type="invalid_request_error",
+            code="invalid_request_error",
+        )
+    if not isinstance(request_data, dict):
+        return openai_error_response(
+            "Request body must be a JSON object",
+            status_code=400,
+            err_type="invalid_request_error",
+            code="invalid_request_error",
+        )
+
     request_id = uuid.uuid4()
     received_ts = time.time()
     return await request_handler.v1_chat_completions(request_data, request_id, received_ts)

--- a/src/backend/server/openai_compat.py
+++ b/src/backend/server/openai_compat.py
@@ -1,0 +1,95 @@
+import base64
+import json
+from typing import Any, Dict, Optional, Tuple
+
+from fastapi.responses import JSONResponse
+
+PARALLAX_HTTP_RESPONSE_ENVELOPE = "__parallax_http_response__"
+
+
+def openai_error_payload(
+    message: str,
+    *,
+    err_type: str = "server_error",
+    param: Optional[str] = None,
+    code: Optional[str] = None,
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        "error": {
+            "message": message,
+            "type": err_type,
+            "param": param,
+            "code": code or err_type,
+        }
+    }
+
+
+def openai_error_response(
+    message: str,
+    *,
+    status_code: int,
+    err_type: str = "server_error",
+    param: Optional[str] = None,
+    code: Optional[str] = None,
+) -> JSONResponse:
+    return JSONResponse(
+        content=openai_error_payload(
+            message,
+            err_type=err_type,
+            param=param,
+            code=code,
+        ),
+        status_code=status_code,
+    )
+
+
+def openai_models_payload(model_name: Optional[str]) -> Dict[str, Any]:
+    models = []
+    if model_name:
+        models.append(
+            {
+                "id": model_name,
+                "object": "model",
+                "created": 0,
+                "owned_by": "parallax",
+            }
+        )
+    return {"object": "list", "data": models}
+
+
+def encode_http_response_envelope(
+    *,
+    status_code: int,
+    content_type: Optional[str],
+    body: bytes,
+) -> bytes:
+    envelope = {
+        PARALLAX_HTTP_RESPONSE_ENVELOPE: True,
+        "status_code": int(status_code),
+        "content_type": content_type or "application/json",
+        "body_base64": base64.b64encode(body).decode("ascii"),
+    }
+    return json.dumps(envelope, separators=(",", ":")).encode("utf-8")
+
+
+def decode_http_response_envelope(content: bytes) -> Optional[Tuple[int, str, bytes]]:
+    try:
+        envelope = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    if not isinstance(envelope, dict) or envelope.get(PARALLAX_HTTP_RESPONSE_ENVELOPE) is not True:
+        return None
+
+    body_base64 = envelope.get("body_base64")
+    if not isinstance(body_base64, str):
+        return None
+
+    try:
+        body = base64.b64decode(body_base64)
+    except ValueError:
+        return None
+
+    status_code = int(envelope.get("status_code", 200))
+    content_type = envelope.get("content_type") or "application/json"
+    return status_code, str(content_type), body

--- a/src/backend/server/request_handler.py
+++ b/src/backend/server/request_handler.py
@@ -3,10 +3,14 @@ import time
 from typing import Dict, List, Optional
 
 import aiohttp
-from fastapi.responses import JSONResponse, Response, StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from starlette.concurrency import iterate_in_threadpool
 
 from backend.server.constants import NODE_STATUS_AVAILABLE
+from backend.server.openai_compat import (
+    decode_http_response_envelope,
+    openai_error_response,
+)
 from parallax_utils.logging_config import get_logger
 from parallax_utils.request_metrics import get_request_metrics
 
@@ -100,9 +104,11 @@ class RequestHandler:
             self.scheduler_manage is None
             or not self.scheduler_manage.get_schedule_status() == NODE_STATUS_AVAILABLE
         ):
-            return JSONResponse(
-                content={"error": "Server is not ready"},
-                status_code=500,
+            return openai_error_response(
+                "Server is not ready",
+                status_code=503,
+                err_type="server_unavailable",
+                code="server_not_ready",
             )
 
         # Try to get a success response
@@ -119,16 +125,20 @@ class RequestHandler:
                     )
                 except Exception as e:
                     logger.exception(f"get_routing_table error: {e}")
-                    return JSONResponse(
-                        content={"error": "Get routing table error"},
+                    return openai_error_response(
+                        "Get routing table error",
                         status_code=500,
+                        err_type="server_error",
+                        code="routing_table_error",
                     )
 
                 # None -> scheduler has not set yet; treat as hard error (no waiting here)
                 if routing_table is None:
-                    return JSONResponse(
-                        content={"error": "Routing pipelines not ready"},
+                    return openai_error_response(
+                        "Routing pipelines not ready",
                         status_code=503,
+                        err_type="server_unavailable",
+                        code="routing_not_ready",
                     )
 
                 # Non-empty -> proceed
@@ -143,9 +153,11 @@ class RequestHandler:
 
             # If still empty after retries, return 429 Too Many Requests
             if routing_table is not None and len(routing_table) == 0:
-                return JSONResponse(
-                    content={"error": "All pipelines are busy or not ready. Please retry later."},
+                return openai_error_response(
+                    "All pipelines are busy or not ready. Please retry later.",
                     status_code=429,
+                    err_type="rate_limit_error",
+                    code="rate_limit_exceeded",
                 )
 
             backend_request = self._prepare_backend_request(
@@ -203,9 +215,21 @@ class RequestHandler:
                     return resp
                 else:
                     response = stub.chat_completion(backend_request)
-                    content = (await anext(iterate_in_threadpool(response))).decode()
+                    content = await anext(iterate_in_threadpool(response))
+                    decoded_response = decode_http_response_envelope(content)
+                    if decoded_response is None:
+                        status_code = 200
+                        content_type = "application/json"
+                        body = content
+                    else:
+                        status_code, content_type, body = decoded_response
                     logger.debug(f"Non-stream response completed for {request_id}")
-                    return Response(content=content, media_type="application/json")
+                    return Response(
+                        content=body,
+                        status_code=status_code,
+                        headers={"content-type": content_type},
+                        media_type=None,
+                    )
             except Exception as e:
                 forward_attempts += 1
                 if forward_attempts < self.MAX_FORWARD_RETRY:
@@ -213,9 +237,11 @@ class RequestHandler:
                     await asyncio.sleep(self.FORWARD_DELAY_SEC)
                 logger.warning(f"Error in _forward_request: {e}. Retry attemps {forward_attempts}")
 
-        return JSONResponse(
-            content={"error": "Internal server error"},
-            status_code=500,
+        return openai_error_response(
+            "Downstream request failed",
+            status_code=502,
+            err_type="upstream_error",
+            code="upstream_error",
         )
 
     async def v1_chat_completions(self, request_data: Dict, request_id: str, received_ts: int):

--- a/src/parallax/p2p/server.py
+++ b/src/parallax/p2p/server.py
@@ -22,6 +22,7 @@ import httpx
 import zmq
 from lattica import ConnectionHandler, Lattica, rpc_method, rpc_stream, rpc_stream_iter
 
+from backend.server.openai_compat import encode_http_response_envelope
 from backend.server.rpc_connection_handler import RPCConnectionHandler
 from parallax.p2p.proto import forward_pb2
 from parallax.p2p.utils import AsyncWorker
@@ -203,10 +204,21 @@ class TransformerConnectionHandler(ConnectionHandler):
                     response = client.post(
                         f"http://localhost:{self.http_port}/v1/chat/completions", json=request
                     )
-                    yield response.content
+                    yield encode_http_response_envelope(
+                        status_code=response.status_code,
+                        content_type=response.headers.get("content-type"),
+                        body=response.content,
+                    )
         except Exception as e:
             logger.exception(f"Error in chat completion: {e}")
-            yield b"internal server error"
+            yield encode_http_response_envelope(
+                status_code=502,
+                content_type="application/json",
+                body=(
+                    b'{"error":{"message":"Internal server error",'
+                    b'"type":"upstream_error","param":null,"code":"upstream_error"}}'
+                ),
+            )
 
 
 def check_and_run_weight_refit(gradient_server, message):

--- a/tests/test_backend_request_handler.py
+++ b/tests/test_backend_request_handler.py
@@ -1,3 +1,11 @@
+import asyncio
+import json
+
+from fastapi.testclient import TestClient
+
+import backend.main as backend_main
+from backend.server.constants import NODE_STATUS_AVAILABLE, NODE_STATUS_WAITING
+from backend.server.openai_compat import encode_http_response_envelope
 from backend.server.request_handler import RequestHandler
 
 
@@ -8,15 +16,59 @@ class DummySchedulerManage:
         return "Qwen/Qwen3-0.6B"
 
 
+class ForwardingSchedulerManage(DummySchedulerManage):
+    def __init__(self, status=NODE_STATUS_AVAILABLE, routing_table=None):
+        self.status = status
+        self.routing_table = ["node-a"] if routing_table is None else routing_table
+
+    def get_schedule_status(self):
+        return self.status
+
+    def get_routing_table(self, request_id, received_ts):
+        return self.routing_table
+
+
+class StaticStub:
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.request = None
+
+    def chat_completion(self, request):
+        self.request = request
+        return iter(self.chunks)
+
+
 def test_prepare_backend_request_uses_vllm_xargs_for_parallax_metadata():
     handler = RequestHandler()
     handler.set_scheduler_manage(DummySchedulerManage())
     request_data = {
-        "messages": [{"role": "user", "content": "hello"}],
+        "model": "client-model",
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "tool", "tool_call_id": "call_1", "content": '{"ok":true}'},
+        ],
         "stream": True,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        "tool_choice": {"type": "function", "function": {"name": "lookup"}},
+        "response_format": {"type": "json_object"},
+        "stream_options": {"include_usage": True},
+        "max_completion_tokens": 42,
+        "extra_future_field": {"kept": True},
         "rid": "old-rid",
         "routing_table": ["old-node"],
-        "vllm_xargs": {"user_arg": 1},
+        "vllm_xargs": {
+            "user_arg": 1,
+            "parallax_routing_table": ["user-node"],
+            "parallax_scheduler_request_id": "user-req",
+        },
     }
 
     backend_request = handler._prepare_backend_request(
@@ -29,9 +81,122 @@ def test_prepare_backend_request_uses_vllm_xargs_for_parallax_metadata():
     assert "routing_table" not in backend_request
     assert backend_request["request_id"] == "scheduler-req"
     assert backend_request["model"] == "Qwen/Qwen3-0.6B"
+    assert backend_request["messages"] == request_data["messages"]
+    assert backend_request["tools"] == request_data["tools"]
+    assert backend_request["tool_choice"] == request_data["tool_choice"]
+    assert backend_request["response_format"] == request_data["response_format"]
+    assert backend_request["stream_options"] == request_data["stream_options"]
+    assert backend_request["max_completion_tokens"] == 42
+    assert backend_request["extra_future_field"] == {"kept": True}
     assert backend_request["vllm_xargs"] == {
         "user_arg": 1,
         "parallax_routing_table": ["node-a", "node-b"],
         "parallax_scheduler_request_id": "scheduler-req",
     }
     assert request_data["routing_table"] == ["old-node"]
+    assert request_data["vllm_xargs"]["parallax_routing_table"] == ["user-node"]
+
+
+def test_forward_request_returns_openai_error_when_scheduler_not_ready():
+    handler = RequestHandler()
+    handler.set_scheduler_manage(ForwardingSchedulerManage(status=NODE_STATUS_WAITING))
+
+    response = asyncio.run(
+        handler.v1_chat_completions(
+            {"messages": [{"role": "user", "content": "hello"}]},
+            "scheduler-req",
+            1.0,
+        )
+    )
+
+    payload = json.loads(response.body)
+    assert response.status_code == 503
+    assert payload["error"]["message"] == "Server is not ready"
+    assert payload["error"]["type"] == "server_unavailable"
+    assert payload["error"]["code"] == "server_not_ready"
+
+
+def test_forward_request_returns_openai_error_when_pipelines_are_busy():
+    handler = RequestHandler()
+    handler.MAX_ROUTING_RETRY = 1
+    handler.set_scheduler_manage(ForwardingSchedulerManage(routing_table=[]))
+
+    response = asyncio.run(
+        handler.v1_chat_completions(
+            {"messages": [{"role": "user", "content": "hello"}]},
+            "scheduler-req",
+            1.0,
+        )
+    )
+
+    payload = json.loads(response.body)
+    assert response.status_code == 429
+    assert payload["error"]["type"] == "rate_limit_error"
+    assert payload["error"]["code"] == "rate_limit_exceeded"
+
+
+def test_forward_request_preserves_non_stream_downstream_status_and_content_type():
+    handler = RequestHandler()
+    handler.set_scheduler_manage(ForwardingSchedulerManage())
+    body = (
+        b'{"error":{"message":"bad request","type":"invalid_request_error",'
+        b'"param":null,"code":"bad_request"}}'
+    )
+    handler.stubs["node-a"] = StaticStub(
+        [
+            encode_http_response_envelope(
+                status_code=400,
+                content_type="application/json; charset=utf-8",
+                body=body,
+            )
+        ]
+    )
+
+    response = asyncio.run(
+        handler.v1_chat_completions(
+            {"messages": [{"role": "user", "content": "hello"}]},
+            "scheduler-req",
+            1.0,
+        )
+    )
+
+    assert response.status_code == 400
+    assert response.body == body
+    assert response.headers["content-type"] == "application/json; charset=utf-8"
+
+
+def test_openai_models_returns_empty_list_without_scheduler(monkeypatch):
+    monkeypatch.setattr(backend_main, "scheduler_manage", None)
+
+    response = TestClient(backend_main.app).get("/v1/models")
+
+    assert response.status_code == 200
+    assert response.json() == {"object": "list", "data": []}
+
+
+def test_openai_models_returns_scheduler_model(monkeypatch):
+    monkeypatch.setattr(backend_main, "scheduler_manage", DummySchedulerManage())
+
+    response = TestClient(backend_main.app).get("/v1/models")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "object": "list",
+        "data": [
+            {
+                "id": "Qwen/Qwen3-0.6B",
+                "object": "model",
+                "created": 0,
+                "owned_by": "parallax",
+            }
+        ],
+    }
+
+
+def test_openai_chat_rejects_non_object_body():
+    response = TestClient(backend_main.app).post("/v1/chat/completions", json=["not-object"])
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error"]["message"] == "Request body must be a JSON object"
+    assert payload["error"]["type"] == "invalid_request_error"


### PR DESCRIPTION
## Summary
- Add `/v1/models` to the scheduler OpenAI gateway.
- Keep `/v1/chat/completions` client fields pass-through while stripping/overriding Parallax-internal routing fields.
- Preserve downstream non-streaming HTTP status/content type over the RPC boundary and return OpenAI-shaped scheduler errors.
- Cover model listing, agent field pass-through, OpenAI errors, and downstream status preservation in tests.

## Validation
- `pre-commit run --all-files`
- `.venv/bin/python -m pytest` (133 passed, 5 skipped)
- Manual README flow: `parallax run -m Qwen/Qwen3-0.6B -n 1`, `parallax join --use-hfcache`, scheduler `/v1/models`, streaming chat completion, tool call request, and follow-up `role: "tool"` response all succeeded.
