### PR TITLE
feat: add mlx chunked prefill support

### DIFF
--- a/src/parallax/server/cache/linear_cache.py
+++ b/src/parallax/server/cache/linear_cache.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import mlx.core as mx
 
@@ -51,6 +51,14 @@ class LinearCache(BaseCache):
 
     def get_cache(self) -> Tuple[Optional[mx.array], Optional[mx.array]]:
         return self.conv_state_cache, self.linear_state_cache
+
+    def get_state_cache_arrays(self) -> List[mx.array]:
+        arrays = []
+        if self.conv_state_cache is not None:
+            arrays.append(self.conv_state_cache)
+        if self.linear_state_cache is not None:
+            arrays.append(self.linear_state_cache)
+        return arrays
 
     def get_indexer_cache(self) -> Optional[mx.array]:
         return None

--- a/src/parallax/server/cache_manager.py
+++ b/src/parallax/server/cache_manager.py
@@ -446,6 +446,14 @@ class CacheManager:
         """Returns the list of layer caches."""
         return self.caches
 
+    def materialize_linear_caches(self):
+        arrays = []
+        for cache in self.caches:
+            if isinstance(cache, LinearCache):
+                arrays.extend(cache.get_state_cache_arrays())
+        if arrays:
+            mx.eval(*arrays)
+
     def match_and_reuse_prefix(self, request_id: str, token_ids: List[int]) -> int:
         """
         Match prefix before prefill and reuse existing blocks.

--- a/src/parallax/server/executor/base_executor.py
+++ b/src/parallax/server/executor/base_executor.py
@@ -741,8 +741,11 @@ class BaseExecutor:
                         # 8. Dispatch to the appropriate destination
                         if self.is_last_peer and self.is_first_peer:
                             # Single node: handle locally
-                            self.handle_input_requests(next_batch)
+                            if next_batch:
+                                self.handle_input_requests(next_batch)
                         elif self.tp_rank == 0:
+                            if not next_batch:
+                                continue
                             # Send output to next peer
                             self.send_to_peer_socket.send_multipart(
                                 [
@@ -833,7 +836,7 @@ class BaseExecutor:
                 request_id=request.request_id,
                 status=RequestStatus.DECODING,
                 current_position=request.total_length + 1,
-                input_ids=request.input_ids,
+                input_ids=request.origin_input_ids,
                 hidden_states=hidden_states,
                 next_token_id=next_token_id,
                 routing_table=request.routing_table,
@@ -852,7 +855,7 @@ class BaseExecutor:
                 request_id=request.request_id,
                 status=RequestStatus.DECODING,  # Last peer always changes status to DECODING
                 current_position=request.total_length,
-                input_ids=request.input_ids,
+                input_ids=request.origin_input_ids,
                 hidden_states=hidden_states,
                 next_token_id=next_token_id,
                 routing_table=request.routing_table,

--- a/src/parallax/server/executor/factory.py
+++ b/src/parallax/server/executor/factory.py
@@ -50,6 +50,7 @@ def create_executor_config(args: argparse.Namespace, shared_state=None, conn=Non
         "max_loaded_loras": args.max_loaded_loras,
         "enable_weight_refit": args.enable_weight_refit,
         "weight_refit_mode": args.weight_refit_mode,
+        "chunked_prefill_size": getattr(args, "chunked_prefill_size", None),
     }
 
     if args.gpu_backend == "sglang":

--- a/src/parallax/server/executor/mlx_executor.py
+++ b/src/parallax/server/executor/mlx_executor.py
@@ -20,6 +20,7 @@ from parallax.server.request import (
 )
 from parallax.server.sampling.sampler import SamplingBatchInfo
 from parallax.server.shard_loader import MLXModelLoader
+from parallax.utils.mac_prefill_adder import AddReqResult, MACPrefillAdder
 from parallax.utils.utils import (
     combine_padding_and_causal_masks,
     create_causal_mask,
@@ -91,6 +92,7 @@ class MLXExecutor(BaseExecutor):
         # Weight Refit
         enable_weight_refit: Optional[bool] = False,
         weight_refit_mode: Optional[str] = "disk",
+        chunked_prefill_size: Optional[int] = None,
         # Pipe communication
         conn: Optional[List[Any]] = [],
     ):
@@ -187,6 +189,15 @@ class MLXExecutor(BaseExecutor):
             kv_block_size,
             self.num_shard_layers,
         )
+        if chunked_prefill_size is not None:
+            if chunked_prefill_size < 0:
+                raise ValueError("chunked_prefill_size must be non-negative")
+            if chunked_prefill_size == 0:
+                chunked_prefill_size = None
+            elif not enable_prefix_cache:
+                enable_prefix_cache = True
+                logger.info("Prefix cache enabled automatically for MLX chunked prefill")
+
         self.cache_manager = CacheManager(
             num_layers=self.num_shard_layers,
             num_kv_heads=num_key_value_heads // tp_size,
@@ -208,6 +219,18 @@ class MLXExecutor(BaseExecutor):
             enable_prefix_cache=enable_prefix_cache,
             sliding_window=sliding_window,
         )
+
+        if chunked_prefill_size is not None:
+            self.chunked_prefill_size = (
+                (chunked_prefill_size + self.cache_manager.block_size - 1)
+                // self.cache_manager.block_size
+                * self.cache_manager.block_size
+            )
+        else:
+            self.chunked_prefill_size = None
+        self.cache_manager.chunked_prefill_size = self.chunked_prefill_size
+        self.cache_manager.defer_prefill_allocation = self.chunked_prefill_size is not None
+
         super().__init__(
             start_layer=start_layer,
             end_layer=end_layer,
@@ -235,6 +258,7 @@ class MLXExecutor(BaseExecutor):
 
         # Prefix Cache Manager
         self.enable_prefix_cache = enable_prefix_cache
+        self.chunked_req = None
         # self.prefix_cache = RadixCache(
         #     num_kv_heads=num_key_value_heads,
         #     head_dim=head_dim,
@@ -272,6 +296,26 @@ class MLXExecutor(BaseExecutor):
         data_arr = mx.distributed.all_sum(data_arr)
         data = pickle.loads(np.array(data_arr).tobytes())
         return data
+
+    def _complete_local_middle_chunk(self, request_id: str):
+        """Finish local bookkeeping after this peer runs a non-final prefill chunk."""
+        if self.chunked_req is None or self.chunked_req.rid != request_id:
+            return
+
+        self.chunked_req.is_chunked = False
+        self.cache_manager.release_request(request_id)
+
+        if self.is_first_peer:
+            original_req = self.scheduler.get_running_request(request_id)
+            if original_req is None:
+                logger.warning(
+                    f"Completed local chunk for {request_id}, but no running request was found."
+                )
+                return
+            original_req.status = RequestStatus.PREFILLING
+            self.scheduler.enque_request(original_req)
+        else:
+            self.scheduler.evict_request(request_id)
 
     def handle_input_requests(self, requests: List[Request]):
         """Update requests states and status in scheduler and cache manager."""
@@ -341,11 +385,6 @@ class MLXExecutor(BaseExecutor):
                     req, IntermediateRequest
                 ), "Non-first peers must receive IntermediateRequests."
                 if req.is_finished or req.hidden_states is None:
-                    if self.enable_prefix_cache:
-                        keys, values = self.cache_manager.gather_kv_cache(req.request_id)
-                        self.prefix_cache.cache_finished_request(req, keys, values)
-                        self.prefix_cache.evict_request(req.request_id)
-
                     self.cache_manager.release_request(req.request_id)
                     logger.debug(
                         f"Released resources for finished request {req.request_id}, "
@@ -357,6 +396,29 @@ class MLXExecutor(BaseExecutor):
                 else:
                     # This is an active request, add it to the scheduler queue to be processed.
                     self.scheduler.enque_request(req)
+
+    def prepare_next_batch_requests(
+        self, requests: List[Request], batch_output: Any, context_lengths: Any
+    ) -> List[Request]:
+        next_batch = super().prepare_next_batch_requests(requests, batch_output, context_lengths)
+        if (
+            self.chunked_req is None
+            or not self.chunked_req.is_chunked
+            or self.chunked_req.rid not in [req.request_id for req in requests]
+        ):
+            return next_batch
+
+        chunked_rid = self.chunked_req.rid
+        filtered_next_batch = []
+        for req in next_batch:
+            if req.request_id == chunked_rid:
+                req.status = RequestStatus.PREFILLING
+                if self.is_last_peer:
+                    continue
+            filtered_next_batch.append(req)
+
+        self._complete_local_middle_chunk(chunked_rid)
+        return filtered_next_batch
 
     def process_batch(self, prepared_inputs: Dict[str, Any], return_decoded_tokens: bool = True):
         """Process a batch of requests in MLX."""
@@ -380,6 +442,8 @@ class MLXExecutor(BaseExecutor):
             prefix_lens=prepared_inputs.get("prefix_lens"),  # For RoPE offset in prefix cache
         )
         mx.eval(hidden_states)
+        if is_prefill_batch and self.chunked_prefill_size is not None:
+            self.cache_manager.materialize_linear_caches()
 
         if logger.isEnabledFor(logging.DEBUG):
             forward_time = (time.time() - start_time) * 1000
@@ -507,6 +571,46 @@ class MLXExecutor(BaseExecutor):
         if batch_size == 0:
             return None
 
+        if self.chunked_prefill_size is not None:
+            original_batched_requests = batched_requests
+            adder = MACPrefillAdder(
+                self.cache_manager.block_size, self.chunked_prefill_size, self.cache_manager
+            )
+            chunked_rid = self.chunked_req.rid if self.chunked_req is not None else None
+
+            if self.chunked_req is not None and chunked_rid in [
+                req.request_id for req in original_batched_requests
+            ]:
+                self.chunked_req = [
+                    req for req in original_batched_requests if req.request_id == chunked_rid
+                ][0]
+                self.chunked_req = adder.add_chunked_req(self.chunked_req)
+
+            for old_req in original_batched_requests:
+                if chunked_rid is not None and old_req.request_id == chunked_rid:
+                    continue
+                res = adder.add_one_req(old_req)
+                if res != AddReqResult.CONTINUE:
+                    break
+
+            if adder.new_chunked_req is not None:
+                self.chunked_req = adder.new_chunked_req
+
+            if self.chunked_req is not None and self.chunked_req.rid in [
+                req.request_id for req in original_batched_requests
+            ]:
+                self.chunked_req.is_chunked = True
+
+            can_run_by_id = {req.request_id: req for req in adder.can_run_list}
+            batched_requests = [
+                can_run_by_id[req.request_id]
+                for req in original_batched_requests
+                if req.request_id in can_run_by_id
+            ]
+            batch_size = len(batched_requests)
+            if batch_size == 0:
+                return None
+
         h_or_tokens_list = []
         block_tables_list = []
         context_lengths_list = []
@@ -555,14 +659,14 @@ class MLXExecutor(BaseExecutor):
                     actual_processed_lengths_list.append(len(req.input_ids))
             else:
                 if matched_tokens > 0 and self.enable_prefix_cache:
-                    # Skip the prefix hidden states that correspond to cached tokens
-                    new_hidden = req.hidden_states[matched_tokens:]
-                    if new_hidden.shape[0] == 0:
+                    keep_len = req.total_length - matched_tokens
+                    if keep_len <= 0:
                         # All tokens cached - keep the last hidden state
                         new_hidden = req.hidden_states[-1:]
                         prefix_lens_list[-1] = matched_tokens - 1
                         actual_processed_lengths_list.append(1)
                     else:
+                        new_hidden = req.hidden_states[-keep_len:]
                         actual_processed_lengths_list.append(new_hidden.shape[0])
                     h_or_tokens_list.append(new_hidden)
                 else:

--- a/src/parallax/server/executor/sglang_executor.py
+++ b/src/parallax/server/executor/sglang_executor.py
@@ -89,6 +89,7 @@ class SGLExecutor(BaseExecutor):
         # Weight Refit
         enable_weight_refit: Optional[bool] = False,
         weight_refit_mode: Optional[str] = "disk",
+        chunked_prefill_size: Optional[int] = None,
         # Pipe communication
         conn: Optional[List[Any]] = [],
     ):

--- a/src/parallax/server/executor/vllm_executor.py
+++ b/src/parallax/server/executor/vllm_executor.py
@@ -88,6 +88,7 @@ class VLLMExecutor(BaseExecutor):
         # Weight Refit
         enable_weight_refit: Optional[bool] = False,
         weight_refit_mode: Optional[str] = "disk",
+        chunked_prefill_size: Optional[int] = None,
         # Routed experts
         enable_return_routed_experts: bool = False,
         # Pipe communication

--- a/src/parallax/server/request.py
+++ b/src/parallax/server/request.py
@@ -109,6 +109,16 @@ class Request:
         self.last_updated_time: Optional[float] = None
         self.lora_id: Optional[str] = None
         self.lora_path = lora_path
+        self.rid = self.request_id
+        self.is_chunked = False
+        # Full prompt tokens as received from the client. Chunked prefill may
+        # temporarily shorten input_ids to the prefix visible to the current
+        # chunk, so keep this immutable source for later chunks and decode.
+        self.origin_input_ids = list(input_ids) if input_ids is not None else None
+        # Optional logical sequence length override for chunked prefill. When
+        # set, total_length reports the end offset of the current prompt chunk
+        # instead of the final prompt+output length.
+        self._effective_total_length: Optional[int] = None
 
     @property
     def is_finished(self) -> bool:
@@ -201,7 +211,9 @@ class InitialRequest(Request):
 
     @property
     def total_length(self) -> int:
-        """Total length of the sequence (input + output)."""
+        """Logical sequence length for scheduling/cache allocation."""
+        if self._effective_total_length is not None:
+            return self._effective_total_length
         return self.prompt_len + self.output_length
 
     def get_model_input_for_first_peer(self) -> List[int]:
@@ -225,6 +237,10 @@ class InitialRequest(Request):
                 f"Request {self.request_id}: Attempted to commit token to a finished request."
             )
             return
+
+        self._effective_total_length = None
+        if self.origin_input_ids is not None:
+            self.input_ids = self.origin_input_ids
 
         self.output_ids.append(token_id)
 
@@ -302,7 +318,9 @@ class IntermediateRequest(Request):
 
     @property
     def total_length(self) -> int:
-        """Total length of the sequence (input + output)."""
+        """Logical sequence length for scheduling/cache allocation."""
+        if self._effective_total_length is not None:
+            return self._effective_total_length
         return self.current_position
 
     @classmethod
@@ -337,7 +355,7 @@ class IntermediateRequest(Request):
         return IntermediateRequest(
             request_id=initial_request.request_id,
             status=initial_request.status,
-            input_ids=initial_request.input_ids,
+            input_ids=initial_request.origin_input_ids,
             next_token_id=next_token_id,
             current_position=initial_request.total_length,
             hidden_states=hidden_states,
@@ -364,7 +382,7 @@ class IntermediateRequest(Request):
             request_id=old_request.request_id,
             status=old_request.status,
             current_position=old_request.total_length,
-            input_ids=old_request.input_ids,
+            input_ids=old_request.origin_input_ids,
             next_token_id=old_request.next_token_id,
             hidden_states=new_hidden_states,
             routing_table=old_request.routing_table,

--- a/src/parallax/server/scheduler.py
+++ b/src/parallax/server/scheduler.py
@@ -141,7 +141,9 @@ class Scheduler:
 
         request.ready_for_next_step = True
         request.last_updated_time = time.time()
-        # TODO: Handle chunked prefill.
+        if request.is_prefill and getattr(request, "origin_input_ids", None) is not None:
+            request.input_ids = request.origin_input_ids
+
         if request.is_decoding:
             rid = request.request_id
             if rid not in self._running_requests:
@@ -259,11 +261,21 @@ class Scheduler:
         while self._wait_queue and len(self._running_requests) < self.max_batch_size:
             req = self._wait_queue.popleft()
             rid = req.request_id
-            if rid in self._running_requests:
+            running_req = self._running_requests.get(rid)
+            if running_req is not None:
+                if req is running_req:
+                    continue
+                if req.is_prefill and running_req.is_prefill:
+                    self._wait_queue.appendleft(req)
+                    break
+                logger.debug(f"Dropping duplicate request {rid} while status={running_req.status}.")
                 continue
 
-            # Check kv cache pool
-            if self.cache_manager is not None:
+            # Check kv cache pool. Chunked prefill performs allocation after the
+            # request is sliced to the current chunk in the executor.
+            if self.cache_manager is not None and not getattr(
+                self.cache_manager, "defer_prefill_allocation", False
+            ):
                 if not self.cache_manager.has_request(req.request_id):
                     # TODO: Handle chunked prefill, and support preemption.
                     # Pass input_ids for prefix cache matching
@@ -348,10 +360,16 @@ class Scheduler:
                     decode_candidates.append(req)
 
         # 1) Fill with prefills first
+        chunked_prefill_size = None
+        if self.cache_manager is not None:
+            chunked_prefill_size = getattr(self.cache_manager, "chunked_prefill_size", None)
+
         for req in prefill_candidates:
             if len(batch) >= self.micro_batch_size:
                 break
-            cost = req.prompt_len
+            cost = req.prompt_len or req.total_length
+            if chunked_prefill_size is not None:
+                cost = min(cost, chunked_prefill_size)
             if cost + inflight_tokens > self.max_num_tokens_per_batch:
                 continue
             batch.append(req)

--- a/src/parallax/server/server_args.py
+++ b/src/parallax/server/server_args.py
@@ -106,7 +106,18 @@ def parse_args() -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--enable-prefix-cache", action="store_true", help="Enable prefix cache reuse"
+        "--disable-prefix-cache",
+        dest="enable_prefix_cache",
+        action="store_false",
+        default=True,
+        help="Disable prefix cache reuse",
+    )
+
+    parser.add_argument(
+        "--chunked-prefill-size",
+        type=int,
+        default=1024,
+        help="Chunk size for MLX chunked prefill processing; set 0 to disable",
     )
 
     # Scheduler configuration
@@ -346,6 +357,13 @@ def validate_args(args: argparse.Namespace) -> None:
 
     if args.kv_block_size <= 0:
         raise ValueError("kv_block_size must be positive")
+
+    chunked_prefill_size = getattr(args, "chunked_prefill_size", None)
+    if chunked_prefill_size is not None:
+        if chunked_prefill_size < 0:
+            raise ValueError("chunked_prefill_size must be non-negative")
+        if chunked_prefill_size == 0:
+            args.chunked_prefill_size = None
 
     if args.micro_batch_ratio <= 0:
         raise ValueError("micro_batch_ratio must be positive")

--- a/src/parallax/utils/mac_prefill_adder.py
+++ b/src/parallax/utils/mac_prefill_adder.py
@@ -1,0 +1,96 @@
+from enum import Enum, auto
+from typing import Optional
+
+from parallax.server.cache_manager import CacheManager
+from parallax.server.request import Request
+
+
+class AddReqResult(Enum):
+    CONTINUE = auto()
+    NO_TOKEN = auto()
+    OTHER = auto()
+
+
+class MACPrefillAdder:
+    """Selects the prompt span to run for MLX chunked prefill."""
+
+    def __init__(
+        self,
+        page_size: int,
+        rem_chunk_tokens: Optional[int],
+        cache_manager: CacheManager,
+    ):
+        self.page_size = page_size
+        self.rem_chunk_tokens = rem_chunk_tokens
+        self.can_run_list: list[Request] = []
+        self.new_chunked_req: Optional[Request] = None
+        self.cache_manager = cache_manager
+
+    def _matched_tokens(self, req: Request) -> int:
+        token_ids = req.origin_input_ids
+        if token_ids is None or self.cache_manager.prefix_cache is None:
+            return 0
+        _, matched_tokens = self.cache_manager.prefix_cache.match_prefix(token_ids)
+        return matched_tokens
+
+    def add_chunked_req(self, chunked_req: Request) -> Optional[Request]:
+        if chunked_req is None or chunked_req.origin_input_ids is None:
+            return None
+
+        matched_tokens = self._matched_tokens(chunked_req)
+        total_len = len(chunked_req.origin_input_ids)
+        remaining_tokens = max(0, total_len - matched_tokens)
+        budget_tokens = max(1, remaining_tokens)
+
+        if self.rem_chunk_tokens is None:
+            truncated = False
+            chunked_req_offset = total_len
+        else:
+            truncated = remaining_tokens > self.rem_chunk_tokens
+            if remaining_tokens == 0:
+                chunked_req_offset = total_len
+            else:
+                chunked_req_offset = min(self.rem_chunk_tokens, remaining_tokens) + matched_tokens
+
+        chunked_req.input_ids = chunked_req.origin_input_ids[:chunked_req_offset]
+        chunked_req._effective_total_length = chunked_req_offset
+        self.can_run_list.append(chunked_req)
+
+        if self.rem_chunk_tokens is not None:
+            self.rem_chunk_tokens -= min(self.rem_chunk_tokens, budget_tokens)
+
+        return chunked_req if truncated else None
+
+    def add_one_req(self, req: Request) -> AddReqResult:
+        if req.origin_input_ids is None:
+            self.can_run_list.append(req)
+            return AddReqResult.CONTINUE
+
+        matched_tokens = self._matched_tokens(req)
+        total_len = len(req.origin_input_ids)
+        remaining_tokens = max(0, total_len - matched_tokens)
+        budget_tokens = max(1, remaining_tokens)
+        extend_input_len = (
+            (remaining_tokens + self.page_size - 1) // self.page_size * self.page_size
+            if remaining_tokens > 0
+            else budget_tokens
+        )
+
+        if self.rem_chunk_tokens is None or extend_input_len <= self.rem_chunk_tokens:
+            self.can_run_list.append(req)
+            if self.rem_chunk_tokens is not None:
+                self.rem_chunk_tokens -= extend_input_len
+        else:
+            trunc_len = self.rem_chunk_tokens // self.page_size * self.page_size
+            if trunc_len <= 0:
+                return AddReqResult.NO_TOKEN
+            chunked_req_offset = trunc_len + matched_tokens
+            req.input_ids = req.origin_input_ids[:chunked_req_offset]
+            req._effective_total_length = chunked_req_offset
+            self.can_run_list.append(req)
+            self.new_chunked_req = req
+            self.rem_chunk_tokens -= trunc_len
+
+        if self.rem_chunk_tokens is None or self.rem_chunk_tokens <= 0:
+            return AddReqResult.OTHER
+        return AddReqResult.CONTINUE

--- a/tests/test_batch_scheduler.py
+++ b/tests/test_batch_scheduler.py
@@ -122,6 +122,38 @@ def test_kv_cache_admission_guard_blocks_prefill():
     assert sched.num_running_requests == 0
 
 
+def test_admission_preserves_distinct_prefill_with_running_rid():
+    sched = Scheduler(max_batch_size=2, max_num_tokens_per_batch=10_000, micro_batch_ratio=1)
+    first_chunk = make_prefill("chunked", 4)
+    next_chunk = make_prefill("chunked", 8)
+
+    sched.enque_request(first_chunk)
+    sched.enque_request(next_chunk)
+    sched.admit_requests()
+
+    assert sched.get_running_request("chunked") is first_chunk
+    assert list(sched._wait_queue) == [next_chunk]
+
+    sched.evict_request("chunked")
+    sched.admit_requests()
+
+    assert sched.get_running_request("chunked") is next_chunk
+    assert sched.num_queued_requests == 0
+
+
+def test_admission_drops_same_object_prefill_requeue():
+    sched = Scheduler(max_batch_size=2, max_num_tokens_per_batch=10_000, micro_batch_ratio=1)
+    req = make_prefill("local-chunk", 4)
+
+    sched.enque_request(req)
+    sched.admit_requests()
+    sched.enque_request(req)
+    sched.admit_requests()
+
+    assert sched.get_running_request("local-chunk") is req
+    assert sched.num_queued_requests == 0
+
+
 def test_request_status_uses_tokenizer_eos_when_config_eos_missing():
     sched = Scheduler(
         max_batch_size=2,

--- a/tests/test_mac_prefill_adder.py
+++ b/tests/test_mac_prefill_adder.py
@@ -1,0 +1,63 @@
+from parallax.server.request import InitialRequest
+from parallax.utils.mac_prefill_adder import AddReqResult, MACPrefillAdder
+
+
+class FakePrefixCache:
+    def __init__(self):
+        self.matched_tokens = 0
+
+    def match_prefix(self, token_ids):
+        return [], min(self.matched_tokens, len(token_ids))
+
+
+class FakeCacheManager:
+    def __init__(self, block_size=4):
+        self.block_size = block_size
+        self.prefix_cache = FakePrefixCache()
+
+
+def test_mac_prefill_adder_chunks_and_restores_effective_length():
+    cache_manager = FakeCacheManager(block_size=4)
+    req = InitialRequest(request_id="req", input_ids=list(range(10)))
+
+    adder = MACPrefillAdder(page_size=4, rem_chunk_tokens=4, cache_manager=cache_manager)
+    result = adder.add_one_req(req)
+
+    assert result == AddReqResult.OTHER
+    assert adder.new_chunked_req is req
+    assert req.input_ids == [0, 1, 2, 3]
+    assert req.total_length == 4
+    assert req.origin_input_ids == list(range(10))
+
+    cache_manager.prefix_cache.matched_tokens = 4
+    adder = MACPrefillAdder(page_size=4, rem_chunk_tokens=4, cache_manager=cache_manager)
+    still_chunked = adder.add_chunked_req(req)
+
+    assert still_chunked is req
+    assert req.input_ids == list(range(8))
+    assert req.total_length == 8
+
+    cache_manager.prefix_cache.matched_tokens = 8
+    adder = MACPrefillAdder(page_size=4, rem_chunk_tokens=4, cache_manager=cache_manager)
+    final_chunk = adder.add_chunked_req(req)
+
+    assert final_chunk is None
+    assert req.input_ids == list(range(10))
+    assert req.total_length == 10
+
+    req.commit_new_token(99)
+    assert req.input_ids == list(range(10))
+    assert req.total_length == 11
+
+
+def test_mac_prefill_adder_full_cache_hit_does_not_extend_past_prompt():
+    cache_manager = FakeCacheManager(block_size=4)
+    cache_manager.prefix_cache.matched_tokens = 8
+    req = InitialRequest(request_id="req", input_ids=list(range(8)))
+
+    adder = MACPrefillAdder(page_size=4, rem_chunk_tokens=4, cache_manager=cache_manager)
+    final_chunk = adder.add_chunked_req(req)
+
+    assert final_chunk is None
+    assert req.input_ids == list(range(8))
+    assert req.total_length == 8

--- a/tests/test_message_util.py
+++ b/tests/test_message_util.py
@@ -143,6 +143,26 @@ class TestMessageUtil:
             np.array(original_request.hidden_states.tolist()),
         )
 
+    def test_chunked_prefill_roundtrip_preserves_full_input_and_position(self):
+        hidden_states = mx.array([[1.0, 2.0], [3.0, 4.0]], dtype=mx.float32)
+        original_request = IntermediateRequest(
+            request_id=self.request_id,
+            input_ids=list(range(8)),
+            current_position=4,
+            status=RequestStatus.PREFILLING,
+            hidden_states=hidden_states,
+            sampling_params=self.sampling_params,
+        )
+
+        proto_request = request_to_proto([original_request])
+        assert proto_request.reqs[0].output_length == -4
+
+        converted_request = proto_to_request(proto_request)
+
+        assert converted_request[0].input_ids == list(range(8))
+        assert converted_request[0].origin_input_ids == list(range(8))
+        assert converted_request[0].current_position == 4
+
     def test_multiple_requests(self):
         """Test conversion of multiple requests."""
         req1 = IntermediateRequest(

--- a/tests/test_mlx_chunked_completion.py
+++ b/tests/test_mlx_chunked_completion.py
@@ -1,5 +1,5 @@
-import numpy as np
 import mlx.core as mx
+import numpy as np
 
 from parallax.server.executor.mlx_executor import MLXExecutor
 from parallax.server.request import InitialRequest, IntermediateRequest, RequestStatus

--- a/tests/test_mlx_chunked_completion.py
+++ b/tests/test_mlx_chunked_completion.py
@@ -1,0 +1,101 @@
+import numpy as np
+import mlx.core as mx
+
+from parallax.server.executor.mlx_executor import MLXExecutor
+from parallax.server.request import InitialRequest, IntermediateRequest, RequestStatus
+
+
+class FakeCacheManager:
+    def __init__(self):
+        self.released = []
+
+    def release_request(self, request_id):
+        self.released.append(request_id)
+
+
+class FakeScheduler:
+    def __init__(self, request):
+        self.request = request
+        self.enqueued = []
+        self.evicted = []
+
+    def get_running_request(self, request_id):
+        if request_id == self.request.request_id:
+            return self.request
+        return None
+
+    def enque_request(self, request):
+        request.ready_for_next_step = True
+        self.enqueued.append(request)
+
+    def evict_request(self, request_id):
+        self.evicted.append(request_id)
+
+
+def make_executor(request, *, is_first_peer=True, is_last_peer=False):
+    executor = object.__new__(MLXExecutor)
+    executor.is_first_peer = is_first_peer
+    executor.is_last_peer = is_last_peer
+    executor.chunked_req = request
+    executor.cache_manager = FakeCacheManager()
+    executor.scheduler = FakeScheduler(request)
+    return executor
+
+
+def test_middle_chunk_completion_requeues_locally_and_returns_downstream_payload():
+    request = InitialRequest.from_prompt_ids(list(range(8)), 4, 16)
+    request.status = RequestStatus.PREFILLING
+    request.input_ids = request.origin_input_ids[:4]
+    request._effective_total_length = 4
+    request.is_chunked = True
+
+    executor = make_executor(request, is_first_peer=True, is_last_peer=False)
+    hidden_states = np.zeros((1, 4, 3), dtype=np.float32)
+
+    downstream_reqs = MLXExecutor.prepare_next_batch_requests(
+        executor,
+        requests=[request],
+        batch_output={"hidden_states": hidden_states, "probs": None},
+        context_lengths=[4],
+    )
+
+    assert len(downstream_reqs) == 1
+    assert downstream_reqs[0].request_id == request.request_id
+    assert downstream_reqs[0].status == RequestStatus.PREFILLING
+    assert downstream_reqs[0].input_ids == request.origin_input_ids
+    assert downstream_reqs[0].current_position == 4
+    assert downstream_reqs[0].hidden_states.shape == (4, 3)
+
+    assert request.is_chunked is False
+    assert executor.cache_manager.released == [request.request_id]
+    assert executor.scheduler.enqueued == [request]
+    assert executor.scheduler.evicted == []
+
+
+def test_last_peer_middle_chunk_completion_drops_sampled_token_payload():
+    request = IntermediateRequest(
+        request_id="chunked-last-peer",
+        current_position=4,
+        status=RequestStatus.PREFILLING,
+        input_ids=list(range(8)),
+        hidden_states=np.zeros((4, 3), dtype=np.float32),
+    )
+    request.input_ids = request.origin_input_ids[:4]
+    request._effective_total_length = 4
+    request.is_chunked = True
+
+    executor = make_executor(request, is_first_peer=False, is_last_peer=True)
+    hidden_states = mx.array([123], dtype=mx.uint32)
+
+    downstream_reqs = MLXExecutor.prepare_next_batch_requests(
+        executor,
+        requests=[request],
+        batch_output={"hidden_states": hidden_states, "probs": [1.0]},
+        context_lengths=[4],
+    )
+
+    assert downstream_reqs == []
+    assert request.is_chunked is False
+    assert executor.cache_manager.released == [request.request_id]
+    assert executor.scheduler.enqueued == []
+    assert executor.scheduler.evicted == [request.request_id]

--- a/tests/test_server_args.py
+++ b/tests/test_server_args.py
@@ -143,6 +143,7 @@ class TestCreateExecutorConfig:
             max_lora_chunk_size=128,
             enable_weight_refit=False,
             weight_refit_mode="cpu",
+            chunked_prefill_size=128,
             gpu_backend="sglang",
         )
 
@@ -153,6 +154,45 @@ class TestCreateExecutorConfig:
         assert config["end_layer"] == 14
         assert config["dtype"] == "bfloat16"
         assert config["kv_cache_memory_fraction"] == 0.8
+        assert config["chunked_prefill_size"] == 128
+
+    def test_chunked_prefill_allows_prefix_cache_auto_enable(self):
+        args = argparse.Namespace(
+            start_layer=0,
+            end_layer=10,
+            dtype="bfloat16",
+            kv_cache_memory_fraction=0.5,
+            max_batch_size=16,
+            max_num_tokens_per_batch=1024,
+            kv_block_size=16,
+            micro_batch_ratio=2,
+            scheduler_wait_ms=500,
+            enable_weight_refit=False,
+            chunked_prefill_size=128,
+            enable_prefix_cache=False,
+        )
+
+        validate_args(args)
+        assert args.chunked_prefill_size == 128
+
+    def test_chunked_prefill_zero_disables(self):
+        args = argparse.Namespace(
+            start_layer=0,
+            end_layer=10,
+            dtype="bfloat16",
+            kv_cache_memory_fraction=0.5,
+            max_batch_size=16,
+            max_num_tokens_per_batch=1024,
+            kv_block_size=16,
+            micro_batch_ratio=2,
+            scheduler_wait_ms=500,
+            enable_weight_refit=False,
+            chunked_prefill_size=0,
+            enable_prefix_cache=False,
+        )
+
+        validate_args(args)
+        assert args.chunked_prefill_size is None
 
 
 class TestParseArgs:
@@ -185,6 +225,25 @@ class TestParseArgs:
         assert args.end_layer == 14
         assert args.dtype == "bfloat16"
         assert args.kv_cache_memory_fraction == 0.8
+        assert args.enable_prefix_cache is True
+        assert args.chunked_prefill_size == 1024
+
+    @patch(
+        "sys.argv",
+        [
+            "test_server_args.py",
+            "--model-path",
+            "mlx-community/Qwen3-0.6B-bf16",
+            "--max-sequence-length",
+            "1024",
+            "--disable-prefix-cache",
+        ],
+    )
+    def test_parse_disable_prefix_cache(self):
+        """Test explicitly disabling prefix cache."""
+        args = parse_args()
+
+        assert args.enable_prefix_cache is False
 
     @patch(
         "sys.argv",


### PR DESCRIPTION
## Summary

- Adds MLX/mac chunked prefill support with chunk-aware request length tracking and prefix-cache backed chunk progression.
- Makes prefix cache enabled by default and adds `--chunked-prefill-size` with a default of 1024; `0` disables chunking.
- Materializes MLX linear caches after prefill chunks to avoid lazy update graph accumulation across chunks.
- Preserves downstream pipeline chunk ordering when multiple chunks for the same request id arrive before the previous chunk finishes.

## Why

Long-prefill requests on macOS MLX could exceed memory because the prefill path ran the full prompt at once. During chunked testing, downstream peers could also drop queued chunks with the same request id, causing two-node pipeline requests to hang. This PR chunks the MLX prefill work, reuses prefix cache state across chunks, and keeps distinct same-rid prefill chunks queued until their turn.

## Validation

- `pre-commit run --all-files`
- `pytest` -> `143 passed, 5 skipped`
- Manual macOS two-node validation with `mlx-community/Qwen3.5-0.8B-MLX-bf16`: node0 hosted layers `[0, 12)`, node1 hosted layers `[12, 24)`, `--chunked-prefill-size 128`; a 1675-token prompt completed successfully with 8 generated tokens.
