### PR TITLE
feat: add sglang chunked prefill support

### DIFF
--- a/src/parallax/server/executor/base_executor.py
+++ b/src/parallax/server/executor/base_executor.py
@@ -94,6 +94,7 @@ class BaseExecutor:
         # Weight Refit
         enable_weight_refit: Optional[bool] = False,
         weight_refit_mode: Optional[str] = "disk",
+        chunked_prefill_size: Optional[int] = None,
         # Pipe communication
         conn: Optional[List[Any]] = [],
     ):
@@ -108,6 +109,7 @@ class BaseExecutor:
         self.finished_batch = []
         self.start_layer = start_layer
         self.end_layer = end_layer
+        self.max_num_tokens_per_batch = max_num_tokens_per_batch
         self._should_stop = False  # Flag to gracefully stop the executor
         # Reference to shared state for layer reallocation detection (when in subprocess mode)
         if shared_state is not None:
@@ -181,6 +183,7 @@ class BaseExecutor:
             cache_manager=self.cache_manager if self.device == "mlx" else None,
             request_timeout_s=request_timeout_s,
             shared_state=self.shared_state,
+            chunked_prefill_size=chunked_prefill_size,
         )
         logger.debug(
             f"Scheduler initialized (max_batch_size={max_batch_size}, max_tokens={max_num_tokens_per_batch}, wait_ms={scheduler_wait_ms})"

--- a/src/parallax/server/executor/mlx_executor.py
+++ b/src/parallax/server/executor/mlx_executor.py
@@ -20,6 +20,10 @@ from parallax.server.request import (
 )
 from parallax.server.sampling.sampler import SamplingBatchInfo
 from parallax.server.shard_loader import MLXModelLoader
+from parallax.utils.chunked_prefill import (
+    complete_local_middle_chunk,
+    filter_middle_chunk_next_batch,
+)
 from parallax.utils.mac_prefill_adder import AddReqResult, MACPrefillAdder
 from parallax.utils.utils import (
     combine_padding_and_causal_masks,
@@ -253,6 +257,7 @@ class MLXExecutor(BaseExecutor):
             shared_state=shared_state,
             enable_weight_refit=enable_weight_refit,
             weight_refit_mode=weight_refit_mode,
+            chunked_prefill_size=self.chunked_prefill_size,
             conn=conn,
         )
 
@@ -299,23 +304,11 @@ class MLXExecutor(BaseExecutor):
 
     def _complete_local_middle_chunk(self, request_id: str):
         """Finish local bookkeeping after this peer runs a non-final prefill chunk."""
-        if self.chunked_req is None or self.chunked_req.rid != request_id:
-            return
-
-        self.chunked_req.is_chunked = False
-        self.cache_manager.release_request(request_id)
-
-        if self.is_first_peer:
-            original_req = self.scheduler.get_running_request(request_id)
-            if original_req is None:
-                logger.warning(
-                    f"Completed local chunk for {request_id}, but no running request was found."
-                )
-                return
-            original_req.status = RequestStatus.PREFILLING
-            self.scheduler.enque_request(original_req)
-        else:
-            self.scheduler.evict_request(request_id)
+        complete_local_middle_chunk(
+            self,
+            request_id,
+            release_callback=self.cache_manager.release_request,
+        )
 
     def handle_input_requests(self, requests: List[Request]):
         """Update requests states and status in scheduler and cache manager."""
@@ -401,24 +394,12 @@ class MLXExecutor(BaseExecutor):
         self, requests: List[Request], batch_output: Any, context_lengths: Any
     ) -> List[Request]:
         next_batch = super().prepare_next_batch_requests(requests, batch_output, context_lengths)
-        if (
-            self.chunked_req is None
-            or not self.chunked_req.is_chunked
-            or self.chunked_req.rid not in [req.request_id for req in requests]
-        ):
-            return next_batch
-
-        chunked_rid = self.chunked_req.rid
-        filtered_next_batch = []
-        for req in next_batch:
-            if req.request_id == chunked_rid:
-                req.status = RequestStatus.PREFILLING
-                if self.is_last_peer:
-                    continue
-            filtered_next_batch.append(req)
-
-        self._complete_local_middle_chunk(chunked_rid)
-        return filtered_next_batch
+        return filter_middle_chunk_next_batch(
+            self,
+            requests,
+            next_batch,
+            release_callback=self.cache_manager.release_request,
+        )
 
     def process_batch(self, prepared_inputs: Dict[str, Any], return_decoded_tokens: bool = True):
         """Process a batch of requests in MLX."""

--- a/src/parallax/server/executor/sglang_executor.py
+++ b/src/parallax/server/executor/sglang_executor.py
@@ -9,6 +9,8 @@ import torch
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.chunk_cache import ChunkCache
+from sglang.srt.mem_cache.common import maybe_cache_unfinished_req, release_kv_cache
 from sglang.srt.mem_cache.radix_cache import RadixCache as PageRadixCache
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.utils.common import SUPPORTED_LORA_TARGET_MODULES
@@ -23,9 +25,11 @@ from parallax.server.request import (
 from parallax.sglang.batch_info import (
     form_sgl_batch_decode,
     form_sgl_batch_prefill,
+    form_sgl_chunked_batch_prefill,
     release_sglang_request,
 )
 from parallax.sglang.model_runner import initialize_sgl_model_runner, refit_sgl_model
+from parallax.utils.chunked_prefill import filter_middle_chunk_next_batch
 from parallax_utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -153,6 +157,11 @@ class SGLExecutor(BaseExecutor):
         if device is None or device == "cuda":
             device = f"cuda:{tp_rank}"
 
+        self.chunked_prefill_size = self._normalize_chunked_prefill_size(
+            chunked_prefill_size, self.model_runner.page_size
+        )
+        self.model_runner.server_args.chunked_prefill_size = self.chunked_prefill_size
+
         super().__init__(
             start_layer=start_layer,
             end_layer=end_layer,
@@ -177,27 +186,46 @@ class SGLExecutor(BaseExecutor):
             shared_state=shared_state,
             enable_weight_refit=enable_weight_refit,
             weight_refit_mode=weight_refit_mode,
+            chunked_prefill_size=self.chunked_prefill_size,
             conn=conn,
         )
         self.cur_batch = None
         self.running_batch = ScheduleBatch(reqs=[], batch_is_full=False)
+        self.sgl_req_by_rid = {}
+        self.sgl_chunked_req = None
+        self.chunked_req = None
         self.tp_group = self.model_runner.tp_group
         self.tp_cpu_group = self.tp_group.cpu_group
 
-        # create a page tree cache for sglang prefill
+        # Create a persistent SGLang tree cache for prefill. When prefix
+        # caching is disabled, ChunkCache still owns unfinished chunk state.
+        cache_params = CacheInitParams(
+            disable=not enable_prefix_cache,
+            req_to_token_pool=self.model_runner.req_to_token_pool,
+            token_to_kv_pool_allocator=self.model_runner.token_to_kv_pool_allocator,
+            page_size=self.model_runner.page_size,
+        )
         if enable_prefix_cache:
-            cache_params = CacheInitParams(
-                disable=False,
-                req_to_token_pool=self.model_runner.req_to_token_pool,
-                token_to_kv_pool_allocator=self.model_runner.token_to_kv_pool_allocator,
-                page_size=self.model_runner.page_size,
-            )
-            self.page_tree_cache = PageRadixCache(cache_params)
+            self.sgl_tree_cache = PageRadixCache(cache_params)
+            self.page_tree_cache = self.sgl_tree_cache
             logger.info(
                 f"Sglang Page tree cache created with page size {self.model_runner.page_size}"
             )
         else:
+            self.sgl_tree_cache = ChunkCache(cache_params)
             self.page_tree_cache = None
+
+    @staticmethod
+    def _normalize_chunked_prefill_size(
+        chunked_prefill_size: Optional[int], page_size: int
+    ) -> Optional[int]:
+        if chunked_prefill_size is None:
+            return None
+        if chunked_prefill_size < 0:
+            raise ValueError("chunked_prefill_size must be non-negative")
+        if chunked_prefill_size == 0:
+            return None
+        return ((chunked_prefill_size + page_size - 1) // page_size) * page_size
 
     def check_and_refit_weight(self, refit_weight_path: str):
         if self.tp_size > 1:
@@ -393,10 +421,22 @@ class SGLExecutor(BaseExecutor):
         )
         logits_output = out.logits_output
 
-        # Merge prefill batch into running batch
+        # Merge completed prefill batches into the running batch. For middle
+        # chunks, keep the SGLang request outside running_batch and stash its
+        # partial KV through SGLang's own cache lifecycle.
         if self.cur_batch:
             if self.cur_batch.forward_mode.is_extend():
-                # Merge the new batch into the running batch
+                if self.cur_batch.chunked_req is not None:
+                    maybe_cache_unfinished_req(
+                        self.cur_batch.chunked_req,
+                        self.cur_batch.tree_cache,
+                        chunked=True,
+                    )
+                    self.sgl_chunked_req = self.cur_batch.chunked_req
+                    self.cur_batch.filter_batch(chunked_req_to_exclude=self.cur_batch.chunked_req)
+                else:
+                    self.sgl_chunked_req = None
+
                 if not self.cur_batch.is_empty():
                     if self.running_batch.is_empty():
                         self.running_batch = self.cur_batch
@@ -437,10 +477,29 @@ class SGLExecutor(BaseExecutor):
 
     def _release_request(self, rid: str):
         """Release per-request resources in SGLang."""
-        try:
-            release_sglang_request(self.running_batch, rid)
-        except Exception:
-            pass
+        sgl_req = self.sgl_req_by_rid.pop(rid, None)
+        in_running_batch = (
+            self.running_batch is not None
+            and not self.running_batch.is_empty()
+            and any(req.rid == rid for req in self.running_batch.reqs)
+        )
+        if in_running_batch:
+            try:
+                release_sglang_request(self.running_batch, rid)
+            except Exception:
+                logger.debug("Failed to release running SGLang request %s", rid, exc_info=True)
+        elif sgl_req is not None and getattr(sgl_req, "req_pool_idx", None) is not None:
+            try:
+                release_kv_cache(sgl_req, self.sgl_tree_cache, is_insert=False)
+            except Exception:
+                try:
+                    self.sgl_tree_cache.req_to_token_pool.free(sgl_req)
+                except Exception:
+                    logger.debug("Failed to release chunked SGLang request %s", rid, exc_info=True)
+        if self.sgl_chunked_req is not None and self.sgl_chunked_req.rid == rid:
+            self.sgl_chunked_req = None
+        if self.chunked_req is not None and self.chunked_req.rid == rid:
+            self.chunked_req = None
 
     def _check_kv_cache_available(self, num_tokens: int) -> bool:
         """
@@ -510,54 +569,30 @@ class SGLExecutor(BaseExecutor):
 
         return broadcast_result
 
+    def prepare_next_batch_requests(
+        self, requests: List[Request], batch_output: Any, context_lengths: Any
+    ) -> List[Request]:
+        next_batch = super().prepare_next_batch_requests(requests, batch_output, context_lengths)
+        return filter_middle_chunk_next_batch(self, requests, next_batch)
+
+    @staticmethod
+    def _slice_prefill_hidden_states(hidden_states: torch.Tensor, extend_len: int) -> torch.Tensor:
+        if hidden_states.ndim == 1:
+            hidden_states = hidden_states.unsqueeze(0)
+        elif hidden_states.ndim == 3:
+            hidden_states = hidden_states.reshape(-1, hidden_states.shape[-1])
+        if hidden_states.shape[0] > extend_len:
+            return hidden_states[-extend_len:]
+        return hidden_states
+
     def _prepare_prefill_batch(self, batched_requests: List[Request]) -> Dict[str, Any]:
         """
         Prepares inputs for CUDA backends from a batch of prefill requests.
         """
 
-        batch_size = len(batched_requests)
-        if batch_size == 0:
+        if len(batched_requests) == 0:
             return None
 
-        # Pre-check: Verify KV cache has enough space for prefill
-        total_tokens_needed = sum(req.total_length for req in batched_requests)
-        if not self._check_kv_cache_available(total_tokens_needed):
-            self._abort_requests_due_to_kv_cache(
-                batched_requests,
-                f"KV cache insufficient for prefill ({total_tokens_needed} tokens needed)",
-            )
-            return None
-
-        # Prepare PP proxy tensors
-        pp_proxy_tensors = None
-        if not self.is_first_peer:
-            hidden_states = torch.cat(
-                [
-                    (
-                        req.hidden_states
-                        if req.hidden_states.ndim == 2
-                        else req.hidden_states.unsqueeze(0)
-                    )
-                    for req in batched_requests
-                ],
-                dim=0,
-            )
-
-            # Create residual tensor with same shape
-            residual = torch.zeros(
-                hidden_states.shape, dtype=hidden_states.dtype, device=hidden_states.device
-            )
-
-            pp_proxy_tensors = PPProxyTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                }
-            )
-            logger.debug(f"PP Proxy: hidden_states shape: {hidden_states.shape}")
-
-        # Prepare lengths (common for both backends)
-        lengths = []
         for req in batched_requests:
             if req.lora_path is not None and self.lora_paths is not None:
                 for lora_ref in self.lora_paths:
@@ -570,23 +605,75 @@ class SGLExecutor(BaseExecutor):
                     if self.lora_paths and len(self.lora_paths) > 0
                     else None
                 )
-            lengths.append(req.total_length)
-        lengths_tensor = torch.tensor(lengths, device=self.device)
 
-        schedule_batch, forward_batch = form_sgl_batch_prefill(
-            batched_requests,
-            self.model_runner,
-            self.page_tree_cache,
-        )
+        if self.chunked_prefill_size is None:
+            schedule_batch, forward_batch = form_sgl_batch_prefill(
+                batched_requests,
+                self.model_runner,
+                self.sgl_tree_cache,
+            )
+            prefill_requests = batched_requests
+        else:
+            prefill_batch = form_sgl_chunked_batch_prefill(
+                requests=batched_requests,
+                model_runner=self.model_runner,
+                tree_cache=self.sgl_tree_cache,
+                sgl_req_by_rid=self.sgl_req_by_rid,
+                running_batch=self.running_batch,
+                chunked_req=self.sgl_chunked_req,
+                chunked_prefill_size=self.chunked_prefill_size,
+                max_num_tokens_per_batch=self.max_num_tokens_per_batch,
+            )
+            if prefill_batch is None:
+                return None
+            schedule_batch = prefill_batch.schedule_batch
+            forward_batch = prefill_batch.forward_batch
+            prefill_requests = prefill_batch.requests
+            self.sgl_chunked_req = prefill_batch.chunked_req
+            self.chunked_req = (
+                next(
+                    (
+                        req
+                        for req in prefill_requests
+                        if self.sgl_chunked_req is not None
+                        and req.request_id == self.sgl_chunked_req.rid
+                    ),
+                    None,
+                )
+                if self.sgl_chunked_req is not None
+                else None
+            )
+
         self.cur_batch = schedule_batch
+        lengths_tensor = torch.tensor(schedule_batch.extend_lens, device=self.device)
+
+        pp_proxy_tensors = None
+        if not self.is_first_peer:
+            hidden_states = torch.cat(
+                [
+                    self._slice_prefill_hidden_states(req.hidden_states, extend_len)
+                    for req, extend_len in zip(prefill_requests, schedule_batch.extend_lens)
+                ],
+                dim=0,
+            )
+            residual = torch.zeros(
+                hidden_states.shape, dtype=hidden_states.dtype, device=hidden_states.device
+            )
+            pp_proxy_tensors = PPProxyTensors(
+                {
+                    "hidden_states": hidden_states,
+                    "residual": residual,
+                }
+            )
+            logger.debug(f"PP Proxy: hidden_states shape: {hidden_states.shape}")
 
         ret = {
             "forward_batch": forward_batch,
             "pp_proxy_tensors": pp_proxy_tensors,
             "context_lengths": lengths_tensor,
-            "requests": batched_requests,
+            "requests": prefill_requests,
         }
-        logger.debug(f"Prepared CUDA prefill batch (sglang, size={batch_size})")
+        logger.debug(f"Prepared CUDA prefill batch (sglang, size={len(prefill_requests)})")
         return ret
 
     def _prepare_decode_batch(self, batched_requests: List[Request]) -> Optional[Dict[str, Any]]:

--- a/src/parallax/server/scheduler.py
+++ b/src/parallax/server/scheduler.py
@@ -56,6 +56,7 @@ class Scheduler:
         cache_manager: Optional[CacheManager] = None,
         request_timeout_s: Optional[int] = 600,
         shared_state: Optional[SharedState] = None,
+        chunked_prefill_size: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -67,6 +68,7 @@ class Scheduler:
             tokenizer: The tokenizer to use for the model;
             cache_manager: The KV cache manager to use for the scheduler.
             request_timeout_s: timeout for each inflight request (default 10mins).
+            chunked_prefill_size: Max tokens to account for each prefill chunk.
         """
         self.max_batch_size = max_batch_size
         self.max_num_tokens_per_batch = max_num_tokens_per_batch
@@ -95,6 +97,7 @@ class Scheduler:
         self._running_requests: Dict[str, Request] = OrderedDict()
 
         self.cache_manager = cache_manager
+        self.chunked_prefill_size = chunked_prefill_size
         self.shared_state = shared_state
         # Default timeout for requests if not set on request object
         self.request_timeout_s = request_timeout_s
@@ -360,9 +363,7 @@ class Scheduler:
                     decode_candidates.append(req)
 
         # 1) Fill with prefills first
-        chunked_prefill_size = None
-        if self.cache_manager is not None:
-            chunked_prefill_size = getattr(self.cache_manager, "chunked_prefill_size", None)
+        chunked_prefill_size = self.chunked_prefill_size
 
         for req in prefill_candidates:
             if len(batch) >= self.micro_batch_size:

--- a/src/parallax/server/server_args.py
+++ b/src/parallax/server/server_args.py
@@ -117,7 +117,7 @@ def parse_args() -> argparse.Namespace:
         "--chunked-prefill-size",
         type=int,
         default=1024,
-        help="Chunk size for MLX chunked prefill processing; set 0 to disable",
+        help="Chunk size for MLX/SGLang chunked prefill processing; set 0 to disable",
     )
 
     # Scheduler configuration

--- a/src/parallax/sglang/batch_info.py
+++ b/src/parallax/sglang/batch_info.py
@@ -5,10 +5,12 @@ The following is the flow of data structures for a batch in SGLang:
 ScheduleBatch -> ModelWorkerBatch -> ForwardBatch
 """
 
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import Dict, List, Optional
 
 import torch
 from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.chunk_cache import ChunkCache
 from sglang.srt.mem_cache.radix_cache import RadixCache as PageRadixCache
@@ -24,9 +26,18 @@ from parallax.server.request import Request
 from parallax.server.sampling.sampling_params import (
     SamplingParams as ParallaxSamplingParams,
 )
+from parallax.utils.chunked_prefill import set_request_prefill_chunk
 from parallax_utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class SGLPrefillBatch:
+    schedule_batch: ScheduleBatch
+    forward_batch: ForwardBatch
+    requests: List[Request]
+    chunked_req: Optional[Req]
 
 
 def transform_sampling_params_to_sglang(old_params: ParallaxSamplingParams) -> SGLSamplingParams:
@@ -58,7 +69,7 @@ def transform_requests_to_sglang(
         req = Req(
             rid=old_req.request_id,
             origin_input_text="",
-            origin_input_ids=old_req.input_ids,
+            origin_input_ids=old_req.origin_input_ids or old_req.input_ids,
             sampling_params=sampling_params,
             lora_id=old_req.lora_id,
         )
@@ -87,6 +98,142 @@ def transform_requests_to_sglang(
 
         reqs.append(req)
     return reqs
+
+
+def _get_or_create_sgl_req(
+    old_req: Request,
+    sgl_req_by_rid: Dict[str, Req],
+) -> Req:
+    req = sgl_req_by_rid.get(old_req.request_id)
+    if req is not None:
+        req.lora_id = old_req.lora_id
+        return req
+
+    sampling_params = transform_sampling_params_to_sglang(old_req.sampling_params)
+    req = Req(
+        rid=old_req.request_id,
+        origin_input_text="",
+        origin_input_ids=old_req.origin_input_ids or old_req.input_ids,
+        sampling_params=sampling_params,
+        lora_id=old_req.lora_id,
+    )
+    sgl_req_by_rid[old_req.request_id] = req
+    return req
+
+
+def _set_dp_token_counts(schedule_batch: ScheduleBatch, model_runner: ModelRunner) -> None:
+    num_tokens = schedule_batch.extend_num_tokens
+    dp_size = model_runner.dp_size
+    if dp_size > 1:
+        schedule_batch.global_num_tokens = [num_tokens] * dp_size
+        schedule_batch.global_num_tokens_for_logprob = [num_tokens] * dp_size
+
+
+def _default_running_batch() -> ScheduleBatch:
+    return ScheduleBatch(reqs=[], batch_is_full=False)
+
+
+def form_sgl_chunked_batch_prefill(
+    requests: List[Request],
+    model_runner: ModelRunner,
+    tree_cache,
+    sgl_req_by_rid: Dict[str, Req],
+    running_batch: Optional[ScheduleBatch],
+    chunked_req: Optional[Req],
+    chunked_prefill_size: Optional[int],
+    max_num_tokens_per_batch: int,
+) -> Optional[SGLPrefillBatch]:
+    """Build a SGLang prefill batch using SGLang's native chunking policy."""
+
+    if not requests:
+        return None
+
+    running_batch = running_batch or _default_running_batch()
+    parallax_req_by_rid = {req.request_id: req for req in requests}
+
+    adder = PrefillAdder(
+        page_size=model_runner.server_args.page_size,
+        tree_cache=tree_cache,
+        token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
+        running_batch=running_batch,
+        new_token_ratio=1.0,
+        rem_input_tokens=max_num_tokens_per_batch,
+        rem_chunk_tokens=chunked_prefill_size,
+        max_running_requests=getattr(model_runner, "max_running_requests", None),
+    )
+
+    active_chunked_rid = (
+        chunked_req.rid
+        if chunked_req is not None and chunked_req.rid in parallax_req_by_rid
+        else None
+    )
+    if active_chunked_rid is not None:
+        chunked_req.init_next_round_input()
+        chunked_req = adder.add_chunked_req(chunked_req)
+
+    for old_req in requests:
+        if old_req.request_id == active_chunked_rid:
+            continue
+        if old_req.request_id not in parallax_req_by_rid:
+            continue
+
+        sgl_req = _get_or_create_sgl_req(old_req, sgl_req_by_rid)
+        if sgl_req is chunked_req:
+            continue
+
+        sgl_req.init_next_round_input(tree_cache)
+        res = adder.add_one_req(
+            sgl_req,
+            has_chunked_req=(chunked_req is not None),
+            truncation_align_size=None,
+        )
+        if res != AddReqResult.CONTINUE:
+            break
+
+    can_run_list = adder.can_run_list
+    if not can_run_list:
+        return None
+
+    if adder.new_chunked_req is not None:
+        chunked_req = adder.new_chunked_req
+
+    selected_requests: List[Request] = []
+    for sgl_req in can_run_list:
+        req = parallax_req_by_rid.get(sgl_req.rid)
+        if req is None:
+            continue
+        is_middle_chunk = chunked_req is not None and sgl_req is chunked_req
+        set_request_prefill_chunk(
+            req,
+            chunk_end=len(sgl_req.fill_ids),
+            is_chunked=is_middle_chunk,
+        )
+        selected_requests.append(req)
+
+    if not selected_requests:
+        return None
+
+    schedule_batch = ScheduleBatch.init_new(
+        reqs=can_run_list,
+        req_to_token_pool=model_runner.req_to_token_pool,
+        token_to_kv_pool_allocator=model_runner.token_to_kv_pool_allocator,
+        tree_cache=tree_cache,
+        model_config=model_runner.model_config,
+        enable_overlap=False,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+        chunked_req=chunked_req,
+    )
+    schedule_batch.prepare_for_extend()
+    _set_dp_token_counts(schedule_batch, model_runner)
+
+    model_worker_batch = schedule_batch.get_model_worker_batch()
+    forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
+    return SGLPrefillBatch(
+        schedule_batch=schedule_batch,
+        forward_batch=forward_batch,
+        requests=selected_requests,
+        chunked_req=chunked_req,
+    )
 
 
 def form_sgl_batch_prefill(
@@ -118,12 +265,7 @@ def form_sgl_batch_prefill(
         spec_algorithm=SpeculativeAlgorithm.NONE,
     )
     schedule_batch.prepare_for_extend()
-
-    num_tokens = schedule_batch.extend_num_tokens
-    dp_size = model_runner.dp_size
-    if dp_size > 1:
-        schedule_batch.global_num_tokens = [num_tokens] * dp_size
-        schedule_batch.global_num_tokens_for_logprob = [num_tokens] * dp_size
+    _set_dp_token_counts(schedule_batch, model_runner)
 
     model_worker_batch = schedule_batch.get_model_worker_batch()
     forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
@@ -259,10 +401,6 @@ def release_sglang_request(running_batch: ScheduleBatch, request_id: str):
 
     # use running batch's tree cache to release kv cache
     tree_cache = running_batch.tree_cache
-
-    # for completed requests, is_insert=True to insert into prefix cache
-    # for aborted requests, is_insert=False to not insert into prefix cache
-    is_insert = True  # can be adjusted based on request status
 
     if isinstance(tree_cache, PageRadixCache):
         tree_cache.cache_finished_req(req)

--- a/src/parallax/utils/chunked_prefill.py
+++ b/src/parallax/utils/chunked_prefill.py
@@ -1,0 +1,75 @@
+"""Backend-neutral helpers for Parallax chunked prefill request state."""
+
+from collections.abc import Callable
+from typing import Optional
+
+from parallax.server.request import Request, RequestStatus
+from parallax_utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def set_request_prefill_chunk(req: Request, chunk_end: int, is_chunked: bool) -> None:
+    """Expose the prompt prefix visible to the current prefill chunk."""
+    if req.origin_input_ids is not None:
+        req.input_ids = req.origin_input_ids[:chunk_end]
+    req._effective_total_length = chunk_end
+    req.is_chunked = is_chunked
+
+
+def complete_local_middle_chunk(
+    executor,
+    request_id: str,
+    release_callback: Optional[Callable[[str], None]] = None,
+) -> bool:
+    """Finish local bookkeeping after a non-final prefill chunk."""
+    chunked_req = getattr(executor, "chunked_req", None)
+    if chunked_req is None or chunked_req.rid != request_id:
+        return False
+
+    chunked_req.is_chunked = False
+    if release_callback is not None:
+        release_callback(request_id)
+
+    if executor.is_first_peer:
+        original_req = executor.scheduler.get_running_request(request_id)
+        if original_req is None:
+            logger.warning(
+                "Completed local chunk for %s, but no running request was found.",
+                request_id,
+            )
+            return True
+        original_req.status = RequestStatus.PREFILLING
+        executor.scheduler.enque_request(original_req)
+    else:
+        executor.scheduler.evict_request(request_id)
+
+    return True
+
+
+def filter_middle_chunk_next_batch(
+    executor,
+    requests: list[Request],
+    next_batch: list[Request],
+    release_callback: Optional[Callable[[str], None]] = None,
+) -> list[Request]:
+    """Drop user-visible output for middle chunks and requeue local work."""
+    chunked_req = getattr(executor, "chunked_req", None)
+    if (
+        chunked_req is None
+        or not chunked_req.is_chunked
+        or chunked_req.rid not in [req.request_id for req in requests]
+    ):
+        return next_batch
+
+    chunked_rid = chunked_req.rid
+    filtered_next_batch = []
+    for req in next_batch:
+        if req.request_id == chunked_rid:
+            req.status = RequestStatus.PREFILLING
+            if executor.is_last_peer:
+                continue
+        filtered_next_batch.append(req)
+
+    complete_local_middle_chunk(executor, chunked_rid, release_callback)
+    return filtered_next_batch

--- a/src/parallax/utils/mac_prefill_adder.py
+++ b/src/parallax/utils/mac_prefill_adder.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from parallax.server.cache_manager import CacheManager
 from parallax.server.request import Request
+from parallax.utils.chunked_prefill import set_request_prefill_chunk
 
 
 class AddReqResult(Enum):
@@ -52,8 +53,7 @@ class MACPrefillAdder:
             else:
                 chunked_req_offset = min(self.rem_chunk_tokens, remaining_tokens) + matched_tokens
 
-        chunked_req.input_ids = chunked_req.origin_input_ids[:chunked_req_offset]
-        chunked_req._effective_total_length = chunked_req_offset
+        set_request_prefill_chunk(chunked_req, chunked_req_offset, truncated)
         self.can_run_list.append(chunked_req)
 
         if self.rem_chunk_tokens is not None:
@@ -85,8 +85,7 @@ class MACPrefillAdder:
             if trunc_len <= 0:
                 return AddReqResult.NO_TOKEN
             chunked_req_offset = trunc_len + matched_tokens
-            req.input_ids = req.origin_input_ids[:chunked_req_offset]
-            req._effective_total_length = chunked_req_offset
+            set_request_prefill_chunk(req, chunked_req_offset, True)
             self.can_run_list.append(req)
             self.new_chunked_req = req
             self.rem_chunk_tokens -= trunc_len

--- a/tests/test_batch_scheduler.py
+++ b/tests/test_batch_scheduler.py
@@ -10,6 +10,7 @@ class FakeCacheManager:
     def __init__(self, allow: bool = True):
         self.allow = allow
         self._reqs = set()
+        self.chunked_prefill_size = None
 
     def has_request(self, request_id: str) -> bool:
         return request_id in self._reqs
@@ -102,6 +103,39 @@ def test_token_budget_prefill_skipped_decode_taken():
     assert ids == ["d"]
     # ready flag should be reset after batching
     assert getattr(d, "ready_for_next_step", False) is False
+
+
+def test_token_budget_uses_explicit_chunked_prefill_size_without_cache_manager():
+    sched = Scheduler(
+        max_batch_size=2,
+        max_num_tokens_per_batch=4,
+        micro_batch_ratio=1,
+        chunked_prefill_size=4,
+    )
+    p = make_prefill("chunked", 16)
+    sched.enque_request(p)
+
+    batch = sched.form_batch()
+
+    assert [r.request_id for r in batch] == ["chunked"]
+
+
+def test_token_budget_does_not_read_chunked_prefill_size_from_cache_manager():
+    cache_mgr = FakeCacheManager()
+    cache_mgr.chunked_prefill_size = 4
+    sched = Scheduler(
+        max_batch_size=2,
+        max_num_tokens_per_batch=4,
+        micro_batch_ratio=1,
+        cache_manager=cache_mgr,
+        chunked_prefill_size=None,
+    )
+    p = make_prefill("unchunked", 16)
+    sched.enque_request(p)
+
+    batch = sched.form_batch()
+
+    assert batch == []
 
 
 def test_kv_cache_admission_guard_blocks_prefill():

--- a/tests/test_mlx_chunked_completion.py
+++ b/tests/test_mlx_chunked_completion.py
@@ -99,3 +99,27 @@ def test_last_peer_middle_chunk_completion_drops_sampled_token_payload():
     assert executor.cache_manager.released == [request.request_id]
     assert executor.scheduler.enqueued == []
     assert executor.scheduler.evicted == [request.request_id]
+
+
+def test_single_peer_middle_chunk_completion_requeues_and_drops_sampled_token():
+    request = InitialRequest.from_prompt_ids(list(range(8)), 4, 16)
+    request.status = RequestStatus.PREFILLING
+    request.input_ids = request.origin_input_ids[:4]
+    request._effective_total_length = 4
+    request.is_chunked = True
+
+    executor = make_executor(request, is_first_peer=True, is_last_peer=True)
+    hidden_states = mx.array([123], dtype=mx.uint32)
+
+    downstream_reqs = MLXExecutor.prepare_next_batch_requests(
+        executor,
+        requests=[request],
+        batch_output={"hidden_states": hidden_states, "probs": [1.0]},
+        context_lengths=[4],
+    )
+
+    assert downstream_reqs == []
+    assert request.is_chunked is False
+    assert executor.cache_manager.released == [request.request_id]
+    assert executor.scheduler.enqueued == [request]
+    assert executor.scheduler.evicted == []

--- a/tests/test_sglang_chunked_prefill.py
+++ b/tests/test_sglang_chunked_prefill.py
@@ -1,0 +1,121 @@
+import pytest
+
+pytest.importorskip("sglang")
+
+import torch
+
+from parallax.server.executor.sglang_executor import SGLExecutor
+
+
+class FakeForwardMode:
+    def is_extend(self):
+        return True
+
+
+class FakeSGLReq:
+    def __init__(self, rid):
+        self.rid = rid
+
+
+class FakeScheduleBatch:
+    def __init__(self, reqs, chunked_req=None):
+        self.reqs = list(reqs)
+        self.chunked_req = chunked_req
+        self.tree_cache = object()
+        self.forward_mode = FakeForwardMode()
+        self.filtered_with = None
+
+    def is_empty(self):
+        return len(self.reqs) == 0
+
+    def filter_batch(self, chunked_req_to_exclude=None):
+        self.filtered_with = chunked_req_to_exclude
+        self.reqs = [req for req in self.reqs if req is not chunked_req_to_exclude]
+
+
+class FakeRunningBatch:
+    def __init__(self):
+        self.reqs = []
+        self.merged = []
+
+    def is_empty(self):
+        return len(self.reqs) == 0
+
+    def merge_batch(self, batch):
+        self.merged.append(batch)
+        self.reqs.extend(batch.reqs)
+
+
+class FakeModelRunner:
+    def forward(self, forward_batch, pp_proxy_tensors=None):
+        logits_output = type(
+            "LogitsOutput",
+            (),
+            {
+                "tensors": {
+                    "hidden_states": torch.zeros((1, 1)),
+                    "residual": torch.zeros((1, 1)),
+                }
+            },
+        )()
+        return type("ForwardOutput", (), {"logits_output": logits_output})()
+
+
+def make_executor(cur_batch, running_batch):
+    executor = object.__new__(SGLExecutor)
+    executor.cur_batch = cur_batch
+    executor.running_batch = running_batch
+    executor.sgl_chunked_req = None
+    executor.model_runner = FakeModelRunner()
+    return executor
+
+
+def test_middle_chunk_is_stashed_and_not_merged(monkeypatch):
+    sgl_req = FakeSGLReq("chunked")
+    cur_batch = FakeScheduleBatch([sgl_req], chunked_req=sgl_req)
+    running_batch = FakeRunningBatch()
+    executor = make_executor(cur_batch, running_batch)
+    stashed = []
+
+    def fake_stash(req, tree_cache, chunked=False):
+        stashed.append((req, tree_cache, chunked))
+
+    monkeypatch.setattr(
+        "parallax.server.executor.sglang_executor.maybe_cache_unfinished_req",
+        fake_stash,
+    )
+
+    output = SGLExecutor.process_batch(
+        executor,
+        {"forward_batch": object(), "pp_proxy_tensors": None, "requests": []},
+        return_decoded_tokens=False,
+    )
+
+    assert output["hidden_states"].shape == (1, 1)
+    assert stashed == [(sgl_req, cur_batch.tree_cache, True)]
+    assert cur_batch.filtered_with is sgl_req
+    assert running_batch.reqs == []
+    assert executor.sgl_chunked_req is sgl_req
+    assert executor.cur_batch is None
+
+
+def test_final_prefill_chunk_is_merged_into_running_batch(monkeypatch):
+    sgl_req = FakeSGLReq("final")
+    cur_batch = FakeScheduleBatch([sgl_req], chunked_req=None)
+    running_batch = FakeRunningBatch()
+    executor = make_executor(cur_batch, running_batch)
+
+    monkeypatch.setattr(
+        "parallax.server.executor.sglang_executor.maybe_cache_unfinished_req",
+        lambda *args, **kwargs: pytest.fail("final chunk should not be stashed"),
+    )
+
+    SGLExecutor.process_batch(
+        executor,
+        {"forward_batch": object(), "pp_proxy_tensors": None, "requests": []},
+        return_decoded_tokens=False,
+    )
+
+    assert executor.running_batch is cur_batch
+    assert executor.sgl_chunked_req is None
+    assert executor.cur_batch is None


### PR DESCRIPTION
## Summary

- Add minimal SGLang chunked-prefill glue that reuses native SGLang `Req`, `PrefillAdder`, `ScheduleBatch`, and unfinished chunk cache lifecycle.
- Align MLX middle-chunk behavior with SGLang semantics through a shared backend-neutral request-state helper.
- Pass `chunked_prefill_size` explicitly into the scheduler and stop reading chunk size indirectly from the cache manager.

## Why

Parallax constructs `ScheduleBatch` directly instead of using the upstream SGLang scheduler, so GPU chunked prefill needed a thin adapter around SGLang's native chunk selection and lifecycle primitives. This keeps the SGLang changes small while avoiding divergent MLX/SGLang chunk semantics.

## Validation

- `uv run --no-sync pre-commit run --all-files`
- `uv run --no-sync pytest`
- Manual SGLang single-node streaming test on `my-windows` with `--chunked-prefill-size 128`
- Manual Mac + Windows/H200 two-node pipeline test with layers split `[0,14)` and `[14,28)`, validating long-prompt semantic output
