### PR TITLE
fix(cli): remove join defaults and set 32k sequence length

### DIFF
--- a/src/parallax/cli.py
+++ b/src/parallax/cli.py
@@ -232,14 +232,6 @@ def join_command(args, passthrough_args: list[str] | None = None):
     passthrough_args = passthrough_args or []
 
     cmd = [sys.executable, str(launch_script)]
-    if not _flag_present(passthrough_args, ["--max-num-tokens-per-batch"]):
-        cmd.extend(["--max-num-tokens-per-batch", "4096"])
-    if not _flag_present(passthrough_args, ["--max-sequence-length"]):
-        cmd.extend(["--max-sequence-length", "7168"])
-    if not _flag_present(passthrough_args, ["--max-batch-size"]):
-        cmd.extend(["--max-batch-size", "8"])
-    if not _flag_present(passthrough_args, ["--kv-block-size"]):
-        cmd.extend(["--kv-block-size", "32"])
 
     # The scheduler address is now taken directly from the parsed arguments.
     cmd.extend(["--scheduler-addr", args.scheduler_addr])

--- a/src/parallax/server/server_args.py
+++ b/src/parallax/server/server_args.py
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--max-sequence-length",
         type=int,
-        default=None,
+        default=32768,
         help="Maximum sequence length for the model",
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,39 @@ def test_serve_command_launches_local_server_without_scheduler(tmp_path):
     assert env["SGLANG_ENABLE_JIT_DEEPGEMM"] == "0"
 
 
+def test_join_command_does_not_inject_runtime_defaults(tmp_path):
+    launch_script = tmp_path / "src" / "parallax" / "launch.py"
+    launch_script.parent.mkdir(parents=True)
+    launch_script.touch()
+
+    args = Namespace(scheduler_addr="auto", skip_upload=True, use_relay=False)
+
+    with (
+        patch.object(cli, "check_python_version"),
+        patch.object(cli, "get_project_root", return_value=Path(tmp_path)),
+        patch.object(cli.sys, "executable", "/repo/.venv/bin/python"),
+        patch.object(cli, "_execute_with_graceful_shutdown") as execute,
+    ):
+        cli.join_command(args, ["--log-level", "DEBUG"])
+
+    cmd = execute.call_args.args[0]
+    env = execute.call_args.kwargs["env"]
+
+    assert cmd == [
+        "/repo/.venv/bin/python",
+        str(launch_script),
+        "--scheduler-addr",
+        "auto",
+        "--log-level",
+        "DEBUG",
+    ]
+    assert "--max-num-tokens-per-batch" not in cmd
+    assert "--max-sequence-length" not in cmd
+    assert "--max-batch-size" not in cmd
+    assert "--kv-block-size" not in cmd
+    assert env["SGLANG_ENABLE_JIT_DEEPGEMM"] == "0"
+
+
 def test_main_dispatches_serve_command_with_passthrough_args():
     with (
         patch.object(

--- a/tests/test_server_args.py
+++ b/tests/test_server_args.py
@@ -198,6 +198,13 @@ class TestCreateExecutorConfig:
 class TestParseArgs:
     """Test argument parsing with mocked sys.argv."""
 
+    @patch("sys.argv", ["test_server_args.py", "--model-path", "test"])
+    def test_parse_default_max_sequence_length(self):
+        """Test max sequence length defaults to 32k."""
+        args = parse_args()
+
+        assert args.max_sequence_length == 32768
+
     @patch(
         "sys.argv",
         [


### PR DESCRIPTION
## Summary

- Stop `parallax join` from injecting runtime default arguments into the launched worker command.
- Set the server-side default `--max-sequence-length` to `32768`.
- Add CLI and server args tests that lock in the new behavior.

## Validation

- `.venv/bin/pre-commit run --all-files`
- `.venv/bin/python -m pytest`

## Notes

`AGENTS.md` has an unrelated local working-tree modification and is intentionally not included in this PR.
